### PR TITLE
Fix broken doc links to geojson spec

### DIFF
--- a/src/feature.rs
+++ b/src/feature.rs
@@ -18,8 +18,7 @@ use {util, Bbox, Error, Geometry};
 
 /// Feature Objects
 ///
-/// [GeoJSON Format Specification § 3.2]
-/// (https://tools.ietf.org/html/rfc7946#section-3.2)
+/// [GeoJSON Format Specification § 3.2](https://tools.ietf.org/html/rfc7946#section-3.2)
 #[derive(Clone, Debug, PartialEq)]
 pub struct Feature {
     pub bbox: Option<Bbox>,
@@ -28,8 +27,7 @@ pub struct Feature {
     pub properties: Option<JsonObject>,
     /// Foreign Members
     ///
-    /// [RFC7946 § 6]
-    /// (https://tools.ietf.org/html/rfc7946#section-6)
+    /// [GeoJSON Format Specification § 6](https://tools.ietf.org/html/rfc7946#section-6)
     pub foreign_members: Option<JsonObject>,
 }
 

--- a/src/feature_collection.rs
+++ b/src/feature_collection.rs
@@ -19,8 +19,7 @@ use {util, Bbox, Error, Feature};
 
 /// Feature Collection Objects
 ///
-/// [GeoJSON Format Specification § 3.3]
-/// (https://tools.ietf.org/html/rfc7946#section-3.3)
+/// [GeoJSON Format Specification § 3.3](https://tools.ietf.org/html/rfc7946#section-3.3)
 ///
 /// # Examples
 ///
@@ -52,8 +51,7 @@ pub struct FeatureCollection {
     pub features: Vec<Feature>,
     /// Foreign Members
     ///
-    /// [RFC7946 § 6]
-    /// (https://tools.ietf.org/html/rfc7946#section-6)
+    /// [GeoJSON Format Specification § 6](https://tools.ietf.org/html/rfc7946#section-6)
     pub foreign_members: Option<JsonObject>,
 }
 

--- a/src/geojson.rs
+++ b/src/geojson.rs
@@ -21,8 +21,7 @@ use {Error, Feature, FeatureCollection, Geometry};
 
 /// GeoJSON Objects
 ///
-/// [GeoJSON Format Specification § 3]
-/// (https://tools.ietf.org/html/rfc7946#section-3)
+/// [GeoJSON Format Specification § 3](https://tools.ietf.org/html/rfc7946#section-3)
 #[derive(Clone, Debug, PartialEq)]
 pub enum GeoJson {
     Geometry(Geometry),

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -37,44 +37,37 @@ use {util, Bbox, Error, LineStringType, PointType, PolygonType};
 pub enum Value {
     /// Point
     ///
-    /// [GeoJSON Format Specification § 3.1.2]
-    /// (https://tools.ietf.org/html/rfc7946#section-3.1.2
+    /// [GeoJSON Format Specification § 3.1.2](https://tools.ietf.org/html/rfc7946#section-3.1.2
     Point(PointType),
 
     /// MultiPoint
     ///
-    /// [GeoJSON Format Specification § 3.1.3]
-    /// (https://tools.ietf.org/html/rfc7946#section-3.1.3
+    /// [GeoJSON Format Specification § 3.1.3](https://tools.ietf.org/html/rfc7946#section-3.1.3
     MultiPoint(Vec<PointType>),
 
     /// LineString
     ///
-    /// [GeoJSON Format Specification § 3.1.4]
-    /// (https://tools.ietf.org/html/rfc7946#section-3.1.4
+    /// [GeoJSON Format Specification § 3.1.4](https://tools.ietf.org/html/rfc7946#section-3.1.4
     LineString(LineStringType),
 
     /// MultiLineString
     ///
-    /// [GeoJSON Format Specification § 3.1.5]
-    /// (https://tools.ietf.org/html/rfc7946#section-3.1.5)
+    /// [GeoJSON Format Specification § 3.1.5](https://tools.ietf.org/html/rfc7946#section-3.1.5)
     MultiLineString(Vec<LineStringType>),
 
     /// Polygon
     ///
-    /// [GeoJSON Format Specification § 3.1.6]
-    /// (https://tools.ietf.org/html/rfc7946#section-3.1.6)
+    /// [GeoJSON Format Specification § 3.1.6](https://tools.ietf.org/html/rfc7946#section-3.1.6)
     Polygon(PolygonType),
 
     /// MultiPolygon
     ///
-    /// [GeoJSON Format Specification § 3.1.7]
-    /// (https://tools.ietf.org/html/rfc7946#section-3.1.7)
+    /// [GeoJSON Format Specification § 3.1.7](https://tools.ietf.org/html/rfc7946#section-3.1.7)
     MultiPolygon(Vec<PolygonType>),
 
     /// GeometryCollection
     ///
-    /// [GeoJSON Format Specification § 3.1.8]
-    /// (https://tools.ietf.org/html/rfc7946#section-3.1.8)
+    /// [GeoJSON Format Specification § 3.1.8](https://tools.ietf.org/html/rfc7946#section-3.1.8)
     GeometryCollection(Vec<Geometry>),
 }
 
@@ -104,16 +97,14 @@ impl Serialize for Value {
 
 /// Geometry Objects
 ///
-/// [GeoJSON Format Specification § 3.1]
-/// (https://tools.ietf.org/html/rfc7946#section-3.1)
+/// [GeoJSON Format Specification § 3.1](https://tools.ietf.org/html/rfc7946#section-3.1)
 #[derive(Clone, Debug, PartialEq)]
 pub struct Geometry {
     pub bbox: Option<Bbox>,
     pub value: Value,
     /// Foreign Members
     ///
-    /// [RFC7946 § 6]
-    /// (https://tools.ietf.org/html/rfc7946#section-6)
+    /// [GeoJSON Format Specification § 6](https://tools.ietf.org/html/rfc7946#section-6)
     pub foreign_members: Option<JsonObject>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,14 +199,12 @@ extern crate num_traits;
 
 /// Bounding Boxes
 ///
-/// [GeoJSON Format Specification § 5]
-/// (https://tools.ietf.org/html/rfc7946#section-5)
+/// [GeoJSON Format Specification § 5](https://tools.ietf.org/html/rfc7946#section-5)
 pub type Bbox = Vec<f64>;
 
 /// Positions
 ///
-/// [GeoJSON Format Specification § 3.1.1]
-/// (https://tools.ietf.org/html/rfc7946#section-3.1.1)
+/// [GeoJSON Format Specification § 3.1.1](https://tools.ietf.org/html/rfc7946#section-3.1.1)
 pub type Position = Vec<f64>;
 
 pub type PointType = Position;


### PR DESCRIPTION
Doc links in markdown are now on one line, in order to fix #101.