### PR TITLE
Update readme by removing outdated reference to rustc-serialize

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,18 +34,17 @@ let geojson = geojson_str.parse::<GeoJson>().unwrap();
 ### Writing
 
 ```rust
-use std::collections::HashMap;
-use rustc_serialize::json::ToJson;
 use geojson::{Feature, GeoJson, Geometry, Value};
+use serde_json::{Map, to_value};
 
 let geometry = Geometry::new(
     Value::Point(vec![-120.66029,35.2812])
 );
 
-let mut properties = HashMap::new();
+let mut properties = Map::new();
 properties.insert(
     String::from("name"),
-    "Firestone Grill".to_json(),
+    to_value("Firestone Grill").unwrap(),
 );
 
 let geojson = GeoJson::Feature(Feature {


### PR DESCRIPTION
The example in the `README.md` file was still using `rustc-serialize` so I updated it in order to reflect the current API.