### PR TITLE
Add `TryFrom` impls for JsonObject and JsonValue

### DIFF
--- a/src/geojson.rs
+++ b/src/geojson.rs
@@ -109,9 +109,9 @@ impl TryFrom<JsonObject> for GeoJson {
         };
         let type_ = type_.ok_or(Error::GeoJsonUnknownType)?;
         match type_ {
-            Type::Feature => Feature::from_json_object(object).map(GeoJson::Feature),
+            Type::Feature => Feature::try_from(object).map(GeoJson::Feature),
             Type::FeatureCollection => {
-                FeatureCollection::from_json_object(object).map(GeoJson::FeatureCollection)
+                FeatureCollection::try_from(object).map(GeoJson::FeatureCollection)
             }
             _ => Geometry::try_from(object).map(GeoJson::Geometry),
         }


### PR DESCRIPTION
For each GeoJson type, an `impl TryFrom<JsonObject>` and `impl
TryFrom<JsonValue>` is added, and the analagous `from_json_object` and
`from_json_value` functions are converted to use the new traits.

This makes it possible to simplify the instantiation of GeoJson types
like this:

```rust
let feature: Feature = json!({
    "type": "Feature",
    "geometry": {
        "type": "Point",
        "coordinates": [102.0, 0.5]
    },
    "properties": null,
}).try_into().unwrap();
```

impls are added for:

* `GeoJson`
* `Geometry`
* `Feature`, and
* `FeatureCollection`.

API stability is maintained - the only change is that the
`from_json_object` methods take `JsonObject` instead of
`mut JsonObject`, but this should not break anything.

Tests are added where appropriate.

This commit expands on #119.