### PR TITLE
Add quick_collection function and revise docs.

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -525,6 +525,7 @@ where
 /// let mut collection: GeometryCollection<f64> = quick_collection(&geojson).unwrap();
 /// ```
 #[cfg(feature = "geo-types")]
+#[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 pub fn quick_collection<T>(gj: &GeoJson) -> Result<geo_types::GeometryCollection<T>, GJError>
     where T: Float
 {

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -172,6 +172,7 @@ where
     )
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<T> TryInto<geo_types::Point<T>> for geometry::Value
 where
     T: Float,
@@ -186,6 +187,7 @@ where
     }
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<'a, T> From<&'a geo_types::Point<T>> for geometry::Value
 where
     T: Float,
@@ -197,6 +199,7 @@ where
     }
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<T> TryInto<geo_types::MultiPoint<T>> for geometry::Value
 where
     T: Float,
@@ -216,6 +219,7 @@ where
     }
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<'a, T> From<&'a geo_types::MultiPoint<T>> for geometry::Value
 where
     T: Float,
@@ -231,6 +235,7 @@ where
     }
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<T> TryInto<geo_types::LineString<T>> for geometry::Value
 where
     T: Float,
@@ -247,6 +252,7 @@ where
     }
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<'a, T> From<&'a geo_types::LineString<T>> for geometry::Value
 where
     T: Float,
@@ -258,6 +264,7 @@ where
     }
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<T> TryInto<geo_types::MultiLineString<T>> for geometry::Value
 where
     T: Float,
@@ -274,6 +281,7 @@ where
     }
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<'a, T> From<&'a geo_types::MultiLineString<T>> for geometry::Value
 where
     T: Float,
@@ -285,6 +293,7 @@ where
     }
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<T> TryInto<geo_types::Polygon<T>> for geometry::Value
 where
     T: Float,
@@ -299,6 +308,7 @@ where
     }
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<'a, T> From<&'a geo_types::Polygon<T>> for geometry::Value
 where
     T: Float,
@@ -310,6 +320,7 @@ where
     }
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<T> TryInto<geo_types::MultiPolygon<T>> for geometry::Value
 where
     T: Float,
@@ -326,6 +337,7 @@ where
     }
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<'a, T> From<&'a geo_types::MultiPolygon<T>> for geometry::Value
 where
     T: Float,
@@ -337,6 +349,7 @@ where
     }
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<T> TryInto<geo_types::GeometryCollection<T>> for geometry::Value
 where
     T: Float,
@@ -358,6 +371,7 @@ where
     }
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<T> TryInto<geo_types::Geometry<T>> for geometry::Value
 where
     T: Float,
@@ -396,6 +410,7 @@ where
     }
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<'a, T> From<&'a geo_types::GeometryCollection<T>> for geometry::Value
 where
     T: Float,
@@ -411,6 +426,7 @@ where
     }
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<'a, T> From<&'a geo_types::Geometry<T>> for geometry::Value
 where
     T: Float,

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -23,11 +23,9 @@ use crate::geojson::GeoJson::{Feature, FeatureCollection, Geometry};
 use crate::geometry;
 use crate::geometry::Geometry as GjGeometry;
 use crate::Error as GJError;
-use crate::Value;
-use crate::{LineStringType, PointType, PolygonType};
+use crate::{LineStringType, PointType, PolygonType, Value};
 use num_traits::Float;
-use std::convert::From;
-use std::convert::TryInto;
+use std::convert::{From, TryInto};
 
 fn create_point_type<T>(point: &geo_types::Point<T>) -> PointType
 where
@@ -513,7 +511,7 @@ where
 /// This function is primarily intended for easy processing of GeoJSON `FeatureCollection`
 /// objects using the `geo` crate, and sacrifices a little performance for convenience.
 /// # Example
-/// 
+///
 /// ```
 /// use geojson::{GeoJson, quick_collection};
 /// use geo_types::GeometryCollection;
@@ -543,7 +541,8 @@ where
 #[cfg(feature = "geo-types")]
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 pub fn quick_collection<T>(gj: &GeoJson) -> Result<geo_types::GeometryCollection<T>, GJError>
-    where T: Float
+where
+    T: Float,
 {
     process_geojson(gj)
 }

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -447,7 +447,6 @@ where
 }
 
 // Process top-level `GeoJSON` items, returning a geo_types::GeometryCollection or an Error
-#[cfg(feature = "geo-types")]
 fn process_geojson<T>(gj: &GeoJson) -> Result<geo_types::GeometryCollection<T>, GJError>
 where
     T: Float,
@@ -474,7 +473,6 @@ where
 }
 
 // Process GeoJson Geometry objects, returning their geo_types equivalents, or an error
-#[cfg(feature = "geo-types")]
 fn process_geometry<T>(geometry: &GjGeometry) -> Result<geo_types::Geometry<T>, GJError>
 where
     T: Float,
@@ -538,7 +536,6 @@ where
 /// // Turn the GeoJSON string into a geo_types GeometryCollection
 /// let mut collection: GeometryCollection<f64> = quick_collection(&geojson).unwrap();
 /// ```
-#[cfg(feature = "geo-types")]
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 pub fn quick_collection<T>(gj: &GeoJson) -> Result<geo_types::GeometryCollection<T>, GJError>
 where

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -522,7 +522,7 @@ where
 /// "#;
 /// let geojson = geojson_str.parse::<GeoJson>().unwrap();
 /// // Turn the GeoJSON string into a geo_types GeometryCollection
-/// let collection: GeometryCollection<f64> = quick_collection(&geojson).unwrap();
+/// let mut collection: GeometryCollection<f64> = quick_collection(&geojson).unwrap();
 /// ```
 #[cfg(feature = "geo-types")]
 pub fn quick_collection<T>(gj: &GeoJson) -> Result<geo_types::GeometryCollection<T>, GJError>

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -21,7 +21,7 @@ use crate::geo_types::{
 use crate::geojson::GeoJson;
 use crate::geojson::GeoJson::{Feature, FeatureCollection, Geometry};
 use crate::geometry;
-use crate::geometry::Geometry as Gh;
+use crate::geometry::Geometry as GjGeometry;
 use crate::Error as GJError;
 use crate::Value;
 use crate::{LineStringType, PointType, PolygonType};
@@ -461,7 +461,7 @@ where
 
 // Process GeoJson Geometry objects, returning their geo_types equivalents, or an error
 #[cfg(feature = "geo-types")]
-fn process_geometry<T>(geometry: &Gh) -> Result<geo_types::Geometry<T>, GJError>
+fn process_geometry<T>(geometry: &GjGeometry) -> Result<geo_types::Geometry<T>, GJError>
 where
     T: Float,
 {

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -432,7 +432,8 @@ where
     }
 }
 
-/// Process top-level `GeoJSON` items
+// Process top-level `GeoJSON` items, returning a geo_types::GeometryCollection or an Error
+#[cfg(feature = "geo-types")]
 fn process_geojson<T>(gj: &GeoJson) -> Result<geo_types::GeometryCollection<T>, GJError>
 where
     T: Float,
@@ -458,6 +459,8 @@ where
     }
 }
 
+// Process GeoJson Geometry objects, returning their geo_types equivalents, or an error
+#[cfg(feature = "geo-types")]
 fn process_geometry<T>(geometry: &Gh) -> Result<geo_types::Geometry<T>, GJError>
 where
     T: Float,
@@ -486,6 +489,46 @@ where
             Ok(gc)
         }
     }
+}
+
+/// A shortcut for producing `geo_types` [GeometryCollection](../geo_types/struct.GeometryCollection.html) objects
+/// from arbitrary valid GeoJSON input.
+///
+/// This function is primarily intended for easy processing of GeoJSON `FeatureCollection`
+/// objects using the `geo` crate, and sacrifices a little performance for convenience.
+/// # Example
+/// 
+/// ```
+/// use geojson::{GeoJson, quick_collection};
+/// use geo_types::GeometryCollection;
+///
+/// let geojson_str = r#"
+/// {
+///   "type": "FeatureCollection",
+///   "features": [
+///     {
+///       "type": "Feature",
+///       "properties": {},
+///       "geometry": {
+///         "type": "Point",
+///         "coordinates": [
+///           -0.13583511114120483,
+///           51.5218870403801
+///         ]
+///       }
+///     }
+///   ]
+/// }
+/// "#;
+/// let geojson = geojson_str.parse::<GeoJson>().unwrap();
+/// // Turn the GeoJSON string into a geo_types GeometryCollection
+/// let collection: GeometryCollection<f64> = quick_collection(&geojson).unwrap();
+/// ```
+#[cfg(feature = "geo-types")]
+pub fn quick_collection<T>(gj: &GeoJson) -> Result<geo_types::GeometryCollection<T>, GJError>
+    where T: Float
+{
+    process_geojson(gj)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,54 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+//!
+//! # Introduction
+//! The `geojson` crate reads and writes `GeoJSON` ([IETF RFC 7946](https://tools.ietf.org/html/rfc7946)) files, optionally using `serde` as a serialisation. Crate users are encouraged to familiarise themselves with the spec, as the crate is structured around it.
+//! framework.
+//! # Structure of the Crate
+//! GeoJSON can contain one of three top-level objects, reflected in the top-level `geojson::GeoJson` types of the same name:
+//! 
+//! - [`Feature`](struct.Feature.html)
+//! - [`FeatureCollection`](struct.FeatureCollection.html)
+//! - [`Geometry`](struct.Geometry.html)
+//! 
+//! With `FeatureCollection` being the most commonly used, since it can contain multiple child objects. A `FeatureCollection` contains `Feature` objects, each of which contains a `Geometry` object. A complicating factor here is the `GeometryCollection` geometry type, which can contain one more `Geometry` objects, _including nested `GeometryCollection` objects_. The use of `GeometryCollection` is discouraged, however.
+//! 
+//! The easiest way to obtain a `GeoJson` object is to call the `parse()` method on a `&str`:
+//! 
+//! # Examples
+//! 
+//! ```
+//! use geojson::GeoJson;
+//! 
+//! let geojson_str = r#"
+//! {
+//!   "type": "FeatureCollection",
+//!   "features": [
+//!     {
+//!       "type": "Feature",
+//!       "properties": {},
+//!       "geometry": {
+//!         "type": "Point",
+//!         "coordinates": [
+//!           -0.13583511114120483,
+//!           51.5218870403801
+//!         ]
+//!       }
+//!     }
+//!   ]
+//! }
+//! "#;
+//! 
+//! let geojson = geojson_str.parse::<GeoJson>().unwrap();
+//! ```
+//! **In most cases it is assumed that you want to convert GeoJSON into `geo` primitive types in order to process, transform, or measure them:**  
+//! - `match` on `geojson`, iterating over its `features` field, yielding `Option<Feature>`.
+//! - process each `Feature`, accessing its `Value` field, yielding `Option<Value>`.
+//! 
+//! Each [`Value`](enum.Value.html) represents a primitive type, such as a coordinate, point, linestring, polygon, or its multi- equivalent1, **and each of these has an equivalent `geo` primitive type**, which you can convert to using the `std::convert::TryFrom` trait.
+//!
+//!
 //! # Examples
 //!
 //! This crate uses `serde` for serialization.
@@ -221,6 +268,8 @@ pub use crate::feature_collection::FeatureCollection;
 
 #[cfg(feature = "geo-types")]
 mod conversion;
+#[cfg(feature = "geo-types")]
+pub use conversion::quick_collection;
 
 /// Feature Objects
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,9 +228,11 @@
 //! the [`geo`](https://docs.rs/geo) crate:
 //!
 //! ```
+//! # #[cfg(feature = "geo-types")]
 //! use geojson::{GeoJson, quick_collection};
+//! # #[cfg(feature = "geo-types")]
 //! use geo_types::GeometryCollection;
-//!
+//! # #[cfg(feature = "geo-types")]
 //! let geojson_str = r#"
 //! {
 //!   "type": "FeatureCollection",
@@ -249,8 +251,10 @@
 //!   ]
 //! }
 //! "#;
+//! # #[cfg(feature = "geo-types")]
 //! let geojson = geojson_str.parse::<GeoJson>().unwrap();
 //! // Turn the GeoJSON string into a geo_types GeometryCollection
+//! # #[cfg(feature = "geo-types")]
 //! let mut collection: GeometryCollection<f64> = quick_collection(&geojson).unwrap();
 //! ```
 //! ### Caveats


### PR DESCRIPTION
The `quick_collection` function is essentially a port of the functionality provided by @lelongg's https://github.com/lelongg/geo-geojson crate: it accepts an arbitrary `geojson::GeoJson` object, and produces a `geo::GeometryCollection` for users who just want to process their geometries using `geo`'s functionality (I suspect this is the primary use case for a lot of users).

The docs have been revised to add more detail about the structure of the crate, how to get started etc, and details about what `quick_collection` does and how it works. They now explicitly point out that you **must** enable the `geo-types` feature in order to use the conversion traits and `quick_collection` – I'm on the fence as to whether this should all just be enabled by default.

As I point out, `quick_collection` potentially sacrifices a little performance due to the use of `clone()` and creating new `Vec`s. I don't think we can do much about the latter, but if anyone wants to have a look at the clone() stuff feel free.