### PR TITLE
Better errors

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+format_code_in_doc_comments = true

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## 0.20.0
 * Switch to thiserror
 * Add more granular errors
+  * `GeoJsonUnknownType` has been split into `NotAFeature` and `EmptyType`
 * Add additional Value context to errors where possible
 
 ## 0.19.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 0.20.0
+* Switch to thiserror
+* Add more granular errors
+* Add additional Value context to errors where possible
+
 ## 0.19.0
 
 * Update `geo-types` to 0.6.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,7 @@
 name = "geojson"
 description = "Library for serializing the GeoJSON vector GIS file format"
 version = "0.19.0"
-authors = ["Corey Farwell <coreyf@rwell.org>",
-           "Blake Grotewold <hello@grotewold.me>"]
+authors = ["The GeoRust Developers <mods@georust.org>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/georust/geojson"
 readme = "README.md"
@@ -17,6 +16,7 @@ serde = "~1.0"
 serde_json = "~1.0"
 geo-types = { version = "0.6", optional = true }
 num-traits = "0.2"
+thiserror = "1.0.20"
 
 [dev-dependencies]
 criterion = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "geojson"
 description = "Library for serializing the GeoJSON vector GIS file format"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["The GeoRust Developers <mods@georust.org>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/georust/geojson"

--- a/src/conversion/mod.rs
+++ b/src/conversion/mod.rs
@@ -138,8 +138,8 @@ where
 /// # Example
 ///
 /// ```
-/// use geojson::{GeoJson, quick_collection};
 /// use geo_types::GeometryCollection;
+/// use geojson::{quick_collection, GeoJson};
 ///
 /// let geojson_str = r#"
 /// {

--- a/src/conversion/to_geo_types.rs
+++ b/src/conversion/to_geo_types.rs
@@ -17,7 +17,7 @@ where
     fn try_into(self) -> Result<geo_types::Point<T>, Self::Error> {
         match self {
             geometry::Value::Point(point_type) => Ok(create_geo_point(&point_type)),
-            _ => Err(GJError::GeometryUnknownType),
+            _ => Err(GJError::InvalidGeometryConversion(self)),
         }
     }
 }
@@ -37,7 +37,7 @@ where
                     .map(|point_type| create_geo_point(&point_type))
                     .collect(),
             )),
-            _ => Err(GJError::GeometryUnknownType),
+            _ => Err(GJError::InvalidGeometryConversion(self)),
         }
     }
 }
@@ -54,7 +54,7 @@ where
             geometry::Value::LineString(multi_point_type) => {
                 Ok(create_geo_line_string(&multi_point_type))
             }
-            _ => Err(GJError::GeometryUnknownType),
+            _ => Err(GJError::InvalidGeometryConversion(self)),
         }
     }
 }
@@ -71,7 +71,7 @@ where
             geometry::Value::MultiLineString(multi_line_string_type) => {
                 Ok(create_geo_multi_line_string(&multi_line_string_type))
             }
-            _ => Err(GJError::GeometryUnknownType),
+            _ => Err(GJError::InvalidGeometryConversion(self)),
         }
     }
 }
@@ -86,7 +86,7 @@ where
     fn try_into(self) -> Result<geo_types::Polygon<T>, Self::Error> {
         match self {
             geometry::Value::Polygon(polygon_type) => Ok(create_geo_polygon(&polygon_type)),
-            _ => Err(GJError::GeometryUnknownType),
+            _ => Err(GJError::InvalidGeometryConversion(self)),
         }
     }
 }
@@ -103,7 +103,7 @@ where
             geometry::Value::MultiPolygon(multi_polygon_type) => {
                 Ok(create_geo_multi_polygon(&multi_polygon_type))
             }
-            _ => Err(GJError::GeometryUnknownType),
+            _ => Err(GJError::InvalidGeometryConversion(self)),
         }
     }
 }
@@ -125,7 +125,7 @@ where
 
                 Ok(geo_types::GeometryCollection(geojson_geometries))
             }
-            _ => Err(GJError::GeometryUnknownType),
+            _ => Err(GJError::InvalidGeometryConversion(self)),
         }
     }
 }
@@ -164,7 +164,7 @@ where
             geometry::Value::MultiPolygon(ref multi_polygon_type) => Ok(
                 geo_types::Geometry::MultiPolygon(create_geo_multi_polygon(multi_polygon_type)),
             ),
-            _ => Err(GJError::GeometryUnknownType),
+            _ => Err(GJError::InvalidGeometryConversion(self)),
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,21 +3,20 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum GJError {
-    // Fixme: can we detail the value?
-    #[error("Encountered non-array type for a 'bbox' object")]
-    BboxExpectedArray,
-    // Fixme: can we detail the value?
+    #[error("Encountered non-array value for a 'bbox' object: `{0}`")]
+    BboxExpectedArray(Value),
     #[error("Encountered non-numeric value within 'bbox' array")]
-    BboxExpectedNumericValues,
-    // Fixme: can we detail the value?
+    BboxExpectedNumericValues(Value),
     #[error("Encountered non-object type for GeoJSON")]
-    GeoJsonExpectedObject,
-    // Fixme: can we detail the value?
-    #[error("Encountered unknown GeoJSON object type")]
-    GeoJsonUnknownType,
-    // Fixme: can we detail the value?
-    #[error("Encountered unknown 'geometry' object type")]
-    GeometryUnknownType,
+    GeoJsonExpectedObject(Value),
+    #[error("Encountered an empty Type")]
+    EmptyType,
+    #[error("Expected a Feature mapping, but got a `{0}`")]
+    NotAFeature(String),
+    #[error("Encountered a mismatch when converting to a Geo type: `{0}`")]
+    InvalidGeometryConversion(Value),
+    #[error("Encountered unknown 'geometry' object type: `{0}`")]
+    GeometryUnknownType(String),
     // Fixme: can we detail the error?
     #[error("Encountered malformed JSON")]
     MalformedJson,
@@ -29,16 +28,16 @@ pub enum GJError {
     FeatureInvalidIdentifierType(Value),
     #[error("Expected GeoJSON type `{expected}`, found `{actual}`")]
     ExpectedType { expected: String, actual: String },
-
-    // FIXME: make these types more specific
-    #[error("Expected a String value")]
-    ExpectedStringValue,
+    #[error("Expected a String value, got a JSONValue: `{0}`")]
+    ExpectedStringValue(Value),
     #[error("Expected a GeoJSON property: `{0}`")]
     ExpectedProperty(String),
-    #[error("Expected a floating-point value")]
+    #[error("Expected a floating-point value, but got None")]
     ExpectedF64Value,
-    #[error("Expected an array value")]
+    #[error("Expected an array value, but got None")]
     ExpectedArrayValue,
-    #[error("Expected an object")]
-    ExpectedObjectValue,
+    #[error("Expected an owned array value, but got `{0}`")]
+    ExpectedOwnedArrayValue(Value),
+    #[error("Expected an owned Object, but got `{0}`")]
+    ExpectedObjectValue(Value),
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -26,7 +26,9 @@ pub enum Error {
     PropertiesExpectedObjectOrNull(Value),
     #[error("Encountered neither object type nor null type for 'geometry' field on 'feature' object: `{0}`")]
     FeatureInvalidGeometryValue(Value),
-    #[error("Encountered neither number type nor string type for 'id' field on 'feature' object: `{0}`")]
+    #[error(
+        "Encountered neither number type nor string type for 'id' field on 'feature' object: `{0}`"
+    )]
     FeatureInvalidIdentifierType(Value),
     #[error("Expected GeoJSON type `{expected}`, found `{actual}`")]
     ExpectedType { expected: String, actual: String },

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -32,9 +32,9 @@ pub enum Error {
     FeatureInvalidIdentifierType(Value),
     #[error("Expected GeoJSON type `{expected}`, found `{actual}`")]
     ExpectedType { expected: String, actual: String },
-    #[error("Expected a String value, got a JSONValue: `{0}`")]
+    #[error("Expected a String value, but got a `{0}`")]
     ExpectedStringValue(Value),
-    #[error("Expected a GeoJSON property: `{0}`")]
+    #[error("Expected a GeoJSON property for `{0}`, but got None")]
     ExpectedProperty(String),
     #[error("Expected a floating-point value, but got None")]
     ExpectedF64Value,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,5 @@
-use thiserror::Error;
 use serde_json::value::Value;
+use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum GJError {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -12,8 +12,10 @@ pub enum Error {
     BboxExpectedNumericValues(Value),
     #[error("Encountered a non-object type for GeoJSON: `{0}`.")]
     GeoJsonExpectedObject(Value),
+    /// This was previously `GeoJsonUnknownType`, but has been split for clarity
     #[error("Expected a Feature, FeatureCollection, or Geometry, but got an empty type.")]
     EmptyType,
+    /// This was previously `GeoJsonUnknownType`, but has been split for clarity
     #[error("Expected a Feature mapping, but got a `{0}`.")]
     NotAFeature(String),
     #[error("Encountered a mismatch when converting to a Geo type: `{0}`.")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,8 +25,8 @@ pub enum GJError {
     PropertiesExpectedObjectOrNull(Value),
     #[error("Encountered neither object type nor null type for 'geometry' field on 'feature' object: `{0}`")]
     FeatureInvalidGeometryValue(Value),
-    #[error("Encountered neither number type nor string type for 'id' field on 'feature' object")]
-    FeatureInvalidIdentifierType,
+    #[error("Encountered neither number type nor string type for 'id' field on 'feature' object: `{0}`")]
+    FeatureInvalidIdentifierType(Value),
     #[error("Expected GeoJSON type `{expected}`, found `{actual}`")]
     ExpectedType { expected: String, actual: String },
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,7 +2,7 @@ use serde_json::value::Value;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-pub enum GJError {
+pub enum Error {
     #[error("Encountered non-array value for a 'bbox' object: `{0}`")]
     BboxExpectedArray(Value),
     #[error("Encountered non-numeric value within 'bbox' array")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,44 @@
+use thiserror::Error;
+use serde_json::value::Value;
+
+#[derive(Error, Debug)]
+pub enum GJError {
+    // Fixme: can we detail the value?
+    #[error("Encountered non-array type for a 'bbox' object")]
+    BboxExpectedArray,
+    // Fixme: can we detail the value?
+    #[error("Encountered non-numeric value within 'bbox' array")]
+    BboxExpectedNumericValues,
+    // Fixme: can we detail the value?
+    #[error("Encountered non-object type for GeoJSON")]
+    GeoJsonExpectedObject,
+    // Fixme: can we detail the value?
+    #[error("Encountered unknown GeoJSON object type")]
+    GeoJsonUnknownType,
+    // Fixme: can we detail the value?
+    #[error("Encountered unknown 'geometry' object type")]
+    GeometryUnknownType,
+    // Fixme: can we detail the error?
+    #[error("Encountered malformed JSON")]
+    MalformedJson,
+    #[error("Encountered neither object type nor null type for 'properties' object: `{0}`")]
+    PropertiesExpectedObjectOrNull(Value),
+    #[error("Encountered neither object type nor null type for 'geometry' field on 'feature' object: `{0}`")]
+    FeatureInvalidGeometryValue(Value),
+    #[error("Encountered neither number type nor string type for 'id' field on 'feature' object")]
+    FeatureInvalidIdentifierType,
+    #[error("Expected GeoJSON type `{expected}`, found `{actual}`")]
+    ExpectedType { expected: String, actual: String },
+
+    // FIXME: make these types more specific
+    #[error("Expected a String value")]
+    ExpectedStringValue,
+    #[error("Expected a GeoJSON property: `{0}`")]
+    ExpectedProperty(String),
+    #[error("Expected a floating-point value")]
+    ExpectedF64Value,
+    #[error("Expected an array value")]
+    ExpectedArrayValue,
+    #[error("Expected an object")]
+    ExpectedObjectValue,
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,7 @@
 //! Module for all GeoJSON-related errors
 use serde_json::value::Value;
 use thiserror::Error;
+use crate::geometry::Value as GValue;
 
 /// Errors which can occur when encoding, decoding, and converting GeoJSON
 #[derive(Error, Debug)]
@@ -16,7 +17,7 @@ pub enum Error {
     #[error("Expected a Feature mapping, but got a `{0}`.")]
     NotAFeature(String),
     #[error("Encountered a mismatch when converting to a Geo type: `{0}`.")]
-    InvalidGeometryConversion(Value),
+    InvalidGeometryConversion(GValue),
     #[error("Encountered an unknown 'geometry' object type: `{0}`")]
     GeometryUnknownType(String),
     // Fixme: can we detail the error?

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -41,10 +41,8 @@ pub enum Error {
     ExpectedProperty(String),
     #[error("Expected a floating-point value, but got None")]
     ExpectedF64Value,
-    #[error("Expected an array value, but got None")]
-    ExpectedArrayValue,
-    #[error("Expected an owned array value, but got `{0}`")]
-    ExpectedOwnedArrayValue(Value),
+    #[error("Expected an Array value, but got `{0}`")]
+    ExpectedArrayValue(String),
     #[error("Expected an owned Object, but got `{0}`")]
     ExpectedObjectValue(Value),
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,24 +1,23 @@
 //! Module for all GeoJSON-related errors
-
 use serde_json::value::Value;
 use thiserror::Error;
 
 /// Errors which can occur when encoding, decoding, and converting GeoJSON
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("Encountered non-array value for a 'bbox' object: `{0}`")]
+    #[error("Encountered non-array value for a 'bbox' object: `{0}`.")]
     BboxExpectedArray(Value),
-    #[error("Encountered non-numeric value within 'bbox' array")]
+    #[error("Encountered non-numeric value within 'bbox' array.")]
     BboxExpectedNumericValues(Value),
-    #[error("Encountered non-object type for GeoJSON")]
+    #[error("Encountered a non-object type for GeoJSON: `{0}`.")]
     GeoJsonExpectedObject(Value),
-    #[error("Encountered an empty Type")]
+    #[error("Expected a Feature, FeatureCollection, or Geometry, but got an empty type.")]
     EmptyType,
-    #[error("Expected a Feature mapping, but got a `{0}`")]
+    #[error("Expected a Feature mapping, but got a `{0}`.")]
     NotAFeature(String),
-    #[error("Encountered a mismatch when converting to a Geo type: `{0}`")]
+    #[error("Encountered a mismatch when converting to a Geo type: `{0}`.")]
     InvalidGeometryConversion(Value),
-    #[error("Encountered unknown 'geometry' object type: `{0}`")]
+    #[error("Encountered an unknown 'geometry' object type: `{0}`")]
     GeometryUnknownType(String),
     // Fixme: can we detail the error?
     #[error("Encountered malformed JSON")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,9 @@
+//! Module for all GeoJSON-related errors
+
 use serde_json::value::Value;
 use thiserror::Error;
 
+/// Errors which can occur when encoding, decoding, and converting GeoJSON
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Encountered non-array value for a 'bbox' object: `{0}`")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,19 +6,19 @@ use crate::geometry::Value as GValue;
 /// Errors which can occur when encoding, decoding, and converting GeoJSON
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("Encountered non-array value for a 'bbox' object: `{0}`.")]
+    #[error("Encountered non-array value for a 'bbox' object: `{0}`")]
     BboxExpectedArray(Value),
-    #[error("Encountered non-numeric value within 'bbox' array.")]
+    #[error("Encountered non-numeric value within 'bbox' array")]
     BboxExpectedNumericValues(Value),
-    #[error("Encountered a non-object type for GeoJSON: `{0}`.")]
+    #[error("Encountered a non-object type for GeoJSON: `{0}`")]
     GeoJsonExpectedObject(Value),
     /// This was previously `GeoJsonUnknownType`, but has been split for clarity
-    #[error("Expected a Feature, FeatureCollection, or Geometry, but got an empty type.")]
+    #[error("Expected a Feature, FeatureCollection, or Geometry, but got an empty type")]
     EmptyType,
     /// This was previously `GeoJsonUnknownType`, but has been split for clarity
-    #[error("Expected a Feature mapping, but got a `{0}`.")]
+    #[error("Expected a Feature mapping, but got a `{0}`")]
     NotAFeature(String),
-    #[error("Encountered a mismatch when converting to a Geo type: `{0}`.")]
+    #[error("Encountered a mismatch when converting to a Geo type: `{0}`")]
     InvalidGeometryConversion(GValue),
     #[error("Encountered an unknown 'geometry' object type: `{0}`")]
     GeometryUnknownType(String),

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -138,7 +138,7 @@ impl Serialize for Id {
 
 #[cfg(test)]
 mod tests {
-    use crate::{feature, Feature, Error, GeoJson, Geometry, Value};
+    use crate::{feature, Error, Feature, GeoJson, Geometry, Value};
 
     fn feature_json_str() -> &'static str {
         "{\"geometry\":{\"coordinates\":[1.1,2.1],\"type\":\"Point\"},\"properties\":{},\"type\":\

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -301,7 +301,7 @@ mod tests {
     fn decode_feature_with_invalid_id_type_object() {
         let feature_json_str = "{\"geometry\":{\"coordinates\":[1.1,2.1],\"type\":\"Point\"},\"id\":{},\"properties\":{},\"type\":\"Feature\"}";
         let result = match feature_json_str.parse::<GeoJson>() {
-            Err(GJError::FeatureInvalidIdentifierType) => true,
+            Err(GJError::FeatureInvalidIdentifierType(_)) => true,
             Ok(_) => false,
             _ => false,
         };
@@ -312,7 +312,7 @@ mod tests {
     fn decode_feature_with_invalid_id_type_null() {
         let feature_json_str = "{\"geometry\":{\"coordinates\":[1.1,2.1],\"type\":\"Point\"},\"id\":null,\"properties\":{},\"type\":\"Feature\"}";
         let result = match feature_json_str.parse::<GeoJson>() {
-            Err(GJError::FeatureInvalidIdentifierType) => true,
+            Err(GJError::FeatureInvalidIdentifierType(_)) => true,
             Ok(_) => false,
             _ => false,
         };

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -67,7 +67,8 @@ impl TryFrom<JsonObject> for Feature {
     type Error = GJError;
 
     fn try_from(mut object: JsonObject) -> Result<Self, GJError> {
-        match &*util::expect_type(&mut object)? {
+        let res = &*util::expect_type(&mut object)?;
+        match res {
             "Feature" => Ok(Feature {
                 geometry: util::get_geometry(&mut object)?,
                 properties: util::get_properties(&mut object)?,
@@ -75,7 +76,7 @@ impl TryFrom<JsonObject> for Feature {
                 bbox: util::get_bbox(&mut object)?,
                 foreign_members: util::get_foreign_members(object)?,
             }),
-            _ => Err(GJError::GeoJsonUnknownType),
+            _ => Err(GJError::NotAFeature(res.to_string())),
         }
     }
 }
@@ -87,7 +88,7 @@ impl TryFrom<JsonValue> for Feature {
         if let JsonValue::Object(obj) = value {
             Self::try_from(obj)
         } else {
-            Err(GJError::GeoJsonExpectedObject)
+            Err(GJError::GeoJsonExpectedObject(value))
         }
     }
 }

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -14,7 +14,7 @@
 
 use std::convert::TryFrom;
 
-use crate::errors::GJError;
+use crate::errors::Error;
 use crate::json::{Deserialize, Deserializer, JsonObject, JsonValue, Serialize, Serializer};
 use crate::serde_json::json;
 use crate::{util, Feature};
@@ -54,19 +54,19 @@ impl<'a> From<&'a Feature> for JsonObject {
 }
 
 impl Feature {
-    pub fn from_json_object(object: JsonObject) -> Result<Self, GJError> {
+    pub fn from_json_object(object: JsonObject) -> Result<Self, Error> {
         Self::try_from(object)
     }
 
-    pub fn from_json_value(value: JsonValue) -> Result<Self, GJError> {
+    pub fn from_json_value(value: JsonValue) -> Result<Self, Error> {
         Self::try_from(value)
     }
 }
 
 impl TryFrom<JsonObject> for Feature {
-    type Error = GJError;
+    type Error = Error;
 
-    fn try_from(mut object: JsonObject) -> Result<Self, GJError> {
+    fn try_from(mut object: JsonObject) -> Result<Self, Error> {
         let res = &*util::expect_type(&mut object)?;
         match res {
             "Feature" => Ok(Feature {
@@ -76,19 +76,19 @@ impl TryFrom<JsonObject> for Feature {
                 bbox: util::get_bbox(&mut object)?,
                 foreign_members: util::get_foreign_members(object)?,
             }),
-            _ => Err(GJError::NotAFeature(res.to_string())),
+            _ => Err(Error::NotAFeature(res.to_string())),
         }
     }
 }
 
 impl TryFrom<JsonValue> for Feature {
-    type Error = GJError;
+    type Error = Error;
 
     fn try_from(value: JsonValue) -> Result<Self, Self::Error> {
         if let JsonValue::Object(obj) = value {
             Self::try_from(obj)
         } else {
-            Err(GJError::GeoJsonExpectedObject(value))
+            Err(Error::GeoJsonExpectedObject(value))
         }
     }
 }
@@ -138,7 +138,7 @@ impl Serialize for Id {
 
 #[cfg(test)]
 mod tests {
-    use crate::{feature, Feature, GJError, GeoJson, Geometry, Value};
+    use crate::{feature, Feature, Error, GeoJson, Geometry, Value};
 
     fn feature_json_str() -> &'static str {
         "{\"geometry\":{\"coordinates\":[1.1,2.1],\"type\":\"Point\"},\"properties\":{},\"type\":\
@@ -241,7 +241,7 @@ mod tests {
     fn feature_json_invalid_geometry() {
         let geojson_str = r#"{"geometry":3.14,"properties":{},"type":"Feature"}"#;
         match geojson_str.parse::<GeoJson>().unwrap_err() {
-            GJError::FeatureInvalidGeometryValue(_) => (),
+            Error::FeatureInvalidGeometryValue(_) => (),
             _ => unreachable!(),
         }
     }
@@ -302,7 +302,7 @@ mod tests {
     fn decode_feature_with_invalid_id_type_object() {
         let feature_json_str = "{\"geometry\":{\"coordinates\":[1.1,2.1],\"type\":\"Point\"},\"id\":{},\"properties\":{},\"type\":\"Feature\"}";
         let result = match feature_json_str.parse::<GeoJson>() {
-            Err(GJError::FeatureInvalidIdentifierType(_)) => true,
+            Err(Error::FeatureInvalidIdentifierType(_)) => true,
             Ok(_) => false,
             _ => false,
         };
@@ -313,7 +313,7 @@ mod tests {
     fn decode_feature_with_invalid_id_type_null() {
         let feature_json_str = "{\"geometry\":{\"coordinates\":[1.1,2.1],\"type\":\"Point\"},\"id\":null,\"properties\":{},\"type\":\"Feature\"}";
         let result = match feature_json_str.parse::<GeoJson>() {
-            Err(GJError::FeatureInvalidIdentifierType(_)) => true,
+            Err(Error::FeatureInvalidIdentifierType(_)) => true,
             Ok(_) => false,
             _ => false,
         };

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -14,10 +14,10 @@
 
 use std::convert::TryFrom;
 
+use crate::errors::GJError;
 use crate::json::{Deserialize, Deserializer, JsonObject, JsonValue, Serialize, Serializer};
 use crate::serde_json::json;
 use crate::{util, Feature};
-use crate::errors::GJError;
 
 impl<'a> From<&'a Feature> for JsonObject {
     fn from(feature: &'a Feature) -> JsonObject {
@@ -137,7 +137,7 @@ impl Serialize for Id {
 
 #[cfg(test)]
 mod tests {
-    use crate::{feature, GJError, Feature, GeoJson, Geometry, Value};
+    use crate::{feature, Feature, GJError, GeoJson, Geometry, Value};
 
     fn feature_json_str() -> &'static str {
         "{\"geometry\":{\"coordinates\":[1.1,2.1],\"type\":\"Point\"},\"properties\":{},\"type\":\
@@ -301,30 +301,22 @@ mod tests {
     fn decode_feature_with_invalid_id_type_object() {
         let feature_json_str = "{\"geometry\":{\"coordinates\":[1.1,2.1],\"type\":\"Point\"},\"id\":{},\"properties\":{},\"type\":\"Feature\"}";
         let result = match feature_json_str.parse::<GeoJson>() {
-            
             Err(GJError::FeatureInvalidIdentifierType) => true,
             Ok(_) => false,
-            _ => false
+            _ => false,
         };
-        assert_eq!(
-            result,
-            true,
-        )
+        assert_eq!(result, true,)
     }
 
     #[test]
     fn decode_feature_with_invalid_id_type_null() {
         let feature_json_str = "{\"geometry\":{\"coordinates\":[1.1,2.1],\"type\":\"Point\"},\"id\":null,\"properties\":{},\"type\":\"Feature\"}";
         let result = match feature_json_str.parse::<GeoJson>() {
-            
             Err(GJError::FeatureInvalidIdentifierType) => true,
             Ok(_) => false,
-            _ => false
+            _ => false,
         };
-        assert_eq!(
-            result,
-            true,
-        )
+        assert_eq!(result, true,)
     }
 
     #[test]

--- a/src/feature_collection.rs
+++ b/src/feature_collection.rs
@@ -14,7 +14,7 @@
 
 use std::convert::TryFrom;
 
-use crate::errors::GJError;
+use crate::errors::Error;
 use crate::json::{Deserialize, Deserializer, JsonObject, JsonValue, Serialize, Serializer};
 use crate::serde_json::json;
 use crate::{util, Bbox, Feature};
@@ -84,26 +84,26 @@ impl<'a> From<&'a FeatureCollection> for JsonObject {
 }
 
 impl FeatureCollection {
-    pub fn from_json_object(object: JsonObject) -> Result<Self, GJError> {
+    pub fn from_json_object(object: JsonObject) -> Result<Self, Error> {
         Self::try_from(object)
     }
 
-    pub fn from_json_value(value: JsonValue) -> Result<Self, GJError> {
+    pub fn from_json_value(value: JsonValue) -> Result<Self, Error> {
         Self::try_from(value)
     }
 }
 
 impl TryFrom<JsonObject> for FeatureCollection {
-    type Error = GJError;
+    type Error = Error;
 
-    fn try_from(mut object: JsonObject) -> Result<Self, GJError> {
+    fn try_from(mut object: JsonObject) -> Result<Self, Error> {
         match util::expect_type(&mut object)? {
             ref type_ if type_ == "FeatureCollection" => Ok(FeatureCollection {
                 bbox: util::get_bbox(&mut object)?,
                 features: util::get_features(&mut object)?,
                 foreign_members: util::get_foreign_members(object)?,
             }),
-            type_ => Err(GJError::ExpectedType {
+            type_ => Err(Error::ExpectedType {
                 expected: "FeatureCollection".to_owned(),
                 actual: type_,
             }),
@@ -112,13 +112,13 @@ impl TryFrom<JsonObject> for FeatureCollection {
 }
 
 impl TryFrom<JsonValue> for FeatureCollection {
-    type Error = GJError;
+    type Error = Error;
 
-    fn try_from(value: JsonValue) -> Result<Self, GJError> {
+    fn try_from(value: JsonValue) -> Result<Self, Error> {
         if let JsonValue::Object(obj) = value {
             Self::try_from(obj)
         } else {
-            Err(GJError::GeoJsonExpectedObject(value))
+            Err(Error::GeoJsonExpectedObject(value))
         }
     }
 }

--- a/src/feature_collection.rs
+++ b/src/feature_collection.rs
@@ -14,10 +14,10 @@
 
 use std::convert::TryFrom;
 
+use crate::errors::GJError;
 use crate::json::{Deserialize, Deserializer, JsonObject, JsonValue, Serialize, Serializer};
 use crate::serde_json::json;
 use crate::{util, Bbox, Feature};
-use crate::errors::GJError;
 
 /// Feature Collection Objects
 ///

--- a/src/feature_collection.rs
+++ b/src/feature_collection.rs
@@ -118,7 +118,7 @@ impl TryFrom<JsonValue> for FeatureCollection {
         if let JsonValue::Object(obj) = value {
             Self::try_from(obj)
         } else {
-            Err(GJError::GeoJsonExpectedObject)
+            Err(GJError::GeoJsonExpectedObject(value))
         }
     }
 }

--- a/src/feature_collection.rs
+++ b/src/feature_collection.rs
@@ -16,7 +16,8 @@ use std::convert::TryFrom;
 
 use crate::json::{Deserialize, Deserializer, JsonObject, JsonValue, Serialize, Serializer};
 use crate::serde_json::json;
-use crate::{util, Bbox, Error, Feature};
+use crate::{util, Bbox, Feature};
+use crate::errors::GJError;
 
 /// Feature Collection Objects
 ///
@@ -83,26 +84,26 @@ impl<'a> From<&'a FeatureCollection> for JsonObject {
 }
 
 impl FeatureCollection {
-    pub fn from_json_object(object: JsonObject) -> Result<Self, Error> {
+    pub fn from_json_object(object: JsonObject) -> Result<Self, GJError> {
         Self::try_from(object)
     }
 
-    pub fn from_json_value(value: JsonValue) -> Result<Self, Error> {
+    pub fn from_json_value(value: JsonValue) -> Result<Self, GJError> {
         Self::try_from(value)
     }
 }
 
 impl TryFrom<JsonObject> for FeatureCollection {
-    type Error = Error;
+    type Error = GJError;
 
-    fn try_from(mut object: JsonObject) -> Result<Self, Error> {
+    fn try_from(mut object: JsonObject) -> Result<Self, GJError> {
         match util::expect_type(&mut object)? {
             ref type_ if type_ == "FeatureCollection" => Ok(FeatureCollection {
                 bbox: util::get_bbox(&mut object)?,
                 features: util::get_features(&mut object)?,
                 foreign_members: util::get_foreign_members(object)?,
             }),
-            type_ => Err(Error::ExpectedType {
+            type_ => Err(GJError::ExpectedType {
                 expected: "FeatureCollection".to_owned(),
                 actual: type_,
             }),
@@ -111,13 +112,13 @@ impl TryFrom<JsonObject> for FeatureCollection {
 }
 
 impl TryFrom<JsonValue> for FeatureCollection {
-    type Error = Error;
+    type Error = GJError;
 
-    fn try_from(value: JsonValue) -> Result<Self, Error> {
+    fn try_from(value: JsonValue) -> Result<Self, GJError> {
         if let JsonValue::Object(obj) = value {
             Self::try_from(obj)
         } else {
-            Err(Error::GeoJsonExpectedObject)
+            Err(GJError::GeoJsonExpectedObject)
         }
     }
 }

--- a/src/geojson.rs
+++ b/src/geojson.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::errors::GJError;
 use crate::json::{self, Deserialize, Deserializer, JsonObject, JsonValue, Serialize, Serializer};
 use crate::serde;
 use crate::{Feature, FeatureCollection, Geometry};
 use std::convert::TryFrom;
 use std::fmt;
 use std::str::FromStr;
-use crate::errors::GJError;
 
 /// GeoJSON Objects
 ///

--- a/src/geojson.rs
+++ b/src/geojson.rs
@@ -108,7 +108,7 @@ impl TryFrom<JsonObject> for GeoJson {
             Some(json::JsonValue::String(t)) => Type::from_str(t),
             _ => return Err(GJError::ExpectedProperty("type".to_owned())),
         };
-        let type_ = type_.ok_or(GJError::GeoJsonUnknownType)?;
+        let type_ = type_.ok_or(GJError::EmptyType)?;
         match type_ {
             Type::Feature => Feature::try_from(object).map(GeoJson::Feature),
             Type::FeatureCollection => {
@@ -126,7 +126,7 @@ impl TryFrom<JsonValue> for GeoJson {
         if let JsonValue::Object(obj) = value {
             Self::try_from(obj)
         } else {
-            Err(GJError::GeoJsonExpectedObject)
+            Err(GJError::GeoJsonExpectedObject(value))
         }
     }
 }

--- a/src/geojson.rs
+++ b/src/geojson.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::errors::GJError;
+use crate::errors::Error;
 use crate::json::{self, Deserialize, Deserializer, JsonObject, JsonValue, Serialize, Serializer};
 use crate::serde;
 use crate::{Feature, FeatureCollection, Geometry};
@@ -59,7 +59,7 @@ impl From<FeatureCollection> for GeoJson {
 }
 
 impl GeoJson {
-    pub fn from_json_object(object: JsonObject) -> Result<Self, GJError> {
+    pub fn from_json_object(object: JsonObject) -> Result<Self, Error> {
         Self::try_from(object)
     }
 
@@ -95,20 +95,20 @@ impl GeoJson {
     ///     })
     /// );
     /// ```
-    pub fn from_json_value(value: JsonValue) -> Result<Self, GJError> {
+    pub fn from_json_value(value: JsonValue) -> Result<Self, Error> {
         Self::try_from(value)
     }
 }
 
 impl TryFrom<JsonObject> for GeoJson {
-    type Error = GJError;
+    type Error = Error;
 
     fn try_from(object: JsonObject) -> Result<Self, Self::Error> {
         let type_ = match object.get("type") {
             Some(json::JsonValue::String(t)) => Type::from_str(t),
-            _ => return Err(GJError::ExpectedProperty("type".to_owned())),
+            _ => return Err(Error::ExpectedProperty("type".to_owned())),
         };
-        let type_ = type_.ok_or(GJError::EmptyType)?;
+        let type_ = type_.ok_or(Error::EmptyType)?;
         match type_ {
             Type::Feature => Feature::try_from(object).map(GeoJson::Feature),
             Type::FeatureCollection => {
@@ -120,13 +120,13 @@ impl TryFrom<JsonObject> for GeoJson {
 }
 
 impl TryFrom<JsonValue> for GeoJson {
-    type Error = GJError;
+    type Error = Error;
 
     fn try_from(value: JsonValue) -> Result<Self, Self::Error> {
         if let JsonValue::Object(obj) = value {
             Self::try_from(obj)
         } else {
-            Err(GJError::GeoJsonExpectedObject(value))
+            Err(Error::GeoJsonExpectedObject(value))
         }
     }
 }
@@ -184,7 +184,7 @@ impl<'de> Deserialize<'de> for GeoJson {
 }
 
 impl FromStr for GeoJson {
-    type Err = GJError;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let object = get_object(s)?;
@@ -193,11 +193,11 @@ impl FromStr for GeoJson {
     }
 }
 
-fn get_object(s: &str) -> Result<json::JsonObject, GJError> {
+fn get_object(s: &str) -> Result<json::JsonObject, Error> {
     ::serde_json::from_str(s)
         .ok()
         .and_then(json_value_into_json_object)
-        .ok_or(GJError::MalformedJson)
+        .ok_or(Error::MalformedJson)
 }
 
 fn json_value_into_json_object(json_value: json::JsonValue) -> Option<json::JsonObject> {

--- a/src/geojson.rs
+++ b/src/geojson.rs
@@ -106,7 +106,7 @@ impl TryFrom<JsonObject> for GeoJson {
     fn try_from(object: JsonObject) -> Result<Self, Self::Error> {
         let type_ = match object.get("type") {
             Some(json::JsonValue::String(t)) => Type::from_str(t),
-            _ => return Err(Error::ExpectedProperty("type".to_owned())),
+            _ => return Err(Error::GeometryUnknownType("type".to_owned())),
         };
         let type_ = type_.ok_or(Error::EmptyType)?;
         match type_ {

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::convert::TryFrom;
+use std::{fmt, convert::TryFrom};
 
 use crate::errors::Error;
 use crate::json::{Deserialize, Deserializer, JsonObject, JsonValue, Serialize, Serializer};
@@ -75,6 +75,12 @@ pub enum Value {
     ///
     /// [GeoJSON Format Specification § 3.1.8](https://tools.ietf.org/html/rfc7946#section-3.1.8)
     GeometryCollection(Vec<Geometry>),
+}
+
+impl fmt::Display for Value {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
 }
 
 impl<'a> From<&'a Value> for JsonValue {

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -14,7 +14,7 @@
 
 use std::convert::TryFrom;
 
-use crate::errors::GJError;
+use crate::errors::Error;
 use crate::json::{Deserialize, Deserializer, JsonObject, JsonValue, Serialize, Serializer};
 use crate::serde;
 use crate::{util, Bbox, LineStringType, PointType, PolygonType};
@@ -209,17 +209,17 @@ impl<'a> From<&'a Geometry> for JsonObject {
 }
 
 impl Geometry {
-    pub fn from_json_object(object: JsonObject) -> Result<Self, GJError> {
+    pub fn from_json_object(object: JsonObject) -> Result<Self, Error> {
         Self::try_from(object)
     }
 
-    pub fn from_json_value(value: JsonValue) -> Result<Self, GJError> {
+    pub fn from_json_value(value: JsonValue) -> Result<Self, Error> {
         Self::try_from(value)
     }
 }
 
 impl TryFrom<JsonObject> for Geometry {
-    type Error = GJError;
+    type Error = Error;
 
     fn try_from(mut object: JsonObject) -> Result<Self, Self::Error> {
         let res = &*util::expect_type(&mut object)?;
@@ -231,7 +231,7 @@ impl TryFrom<JsonObject> for Geometry {
             "Polygon" => Value::Polygon(util::get_coords_2d_pos(&mut object)?),
             "MultiPolygon" => Value::MultiPolygon(util::get_coords_3d_pos(&mut object)?),
             "GeometryCollection" => Value::GeometryCollection(util::get_geometries(&mut object)?),
-            _ => return Err(GJError::GeometryUnknownType(res.to_string())),
+            _ => return Err(Error::GeometryUnknownType(res.to_string())),
         };
         let bbox = util::get_bbox(&mut object)?;
         let foreign_members = util::get_foreign_members(object)?;
@@ -244,13 +244,13 @@ impl TryFrom<JsonObject> for Geometry {
 }
 
 impl TryFrom<JsonValue> for Geometry {
-    type Error = GJError;
+    type Error = Error;
 
     fn try_from(value: JsonValue) -> Result<Self, Self::Error> {
         if let JsonValue::Object(obj) = value {
             Self::try_from(obj)
         } else {
-            Err(GJError::GeoJsonExpectedObject(value))
+            Err(Error::GeoJsonExpectedObject(value))
         }
     }
 }

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -222,7 +222,8 @@ impl TryFrom<JsonObject> for Geometry {
     type Error = GJError;
 
     fn try_from(mut object: JsonObject) -> Result<Self, Self::Error> {
-        let value = match &*util::expect_type(&mut object)? {
+        let res = &*util::expect_type(&mut object)?;
+        let value = match res {
             "Point" => Value::Point(util::get_coords_one_pos(&mut object)?),
             "MultiPoint" => Value::MultiPoint(util::get_coords_1d_pos(&mut object)?),
             "LineString" => Value::LineString(util::get_coords_1d_pos(&mut object)?),
@@ -230,7 +231,7 @@ impl TryFrom<JsonObject> for Geometry {
             "Polygon" => Value::Polygon(util::get_coords_2d_pos(&mut object)?),
             "MultiPolygon" => Value::MultiPolygon(util::get_coords_3d_pos(&mut object)?),
             "GeometryCollection" => Value::GeometryCollection(util::get_geometries(&mut object)?),
-            _ => return Err(GJError::GeometryUnknownType),
+            _ => return Err(GJError::GeometryUnknownType(res.to_string())),
         };
         let bbox = util::get_bbox(&mut object)?;
         let foreign_members = util::get_foreign_members(object)?;
@@ -249,7 +250,7 @@ impl TryFrom<JsonValue> for Geometry {
         if let JsonValue::Object(obj) = value {
             Self::try_from(obj)
         } else {
-            Err(GJError::GeoJsonExpectedObject)
+            Err(GJError::GeoJsonExpectedObject(value))
         }
     }
 }

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -14,10 +14,10 @@
 
 use std::convert::TryFrom;
 
+use crate::errors::GJError;
 use crate::json::{Deserialize, Deserializer, JsonObject, JsonValue, Serialize, Serializer};
 use crate::serde;
 use crate::{util, Bbox, LineStringType, PointType, PolygonType};
-use crate::errors::GJError;
 
 /// The underlying value for a `Geometry`.
 ///
@@ -112,9 +112,7 @@ impl Serialize for Value {
 /// ```
 /// use geojson::{Geometry, Value};
 ///
-/// let geometry = Geometry::new(
-///     Value::Point(vec![7.428959, 1.513394]),
-/// );
+/// let geometry = Geometry::new(Value::Point(vec![7.428959, 1.513394]));
 /// ```
 ///
 /// Serializing a `Geometry` to a GeoJSON string:
@@ -123,9 +121,7 @@ impl Serialize for Value {
 /// use geojson::{GeoJson, Geometry, Value};
 /// use serde_json;
 ///
-/// let geometry = Geometry::new(
-///     Value::Point(vec![7.428959, 1.513394]),
-/// );
+/// let geometry = Geometry::new(Value::Point(vec![7.428959, 1.513394]));
 ///
 /// let geojson_string = geometry.to_string();
 ///
@@ -148,9 +144,7 @@ impl Serialize for Value {
 /// };
 ///
 /// assert_eq!(
-///     Geometry::new(
-///         Value::Point(vec![7.428959, 1.513394]),
-///     ),
+///     Geometry::new(Value::Point(vec![7.428959, 1.513394]),),
 ///     geometry,
 /// );
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,13 +81,10 @@
 //! ```
 //! use serde_json;
 //!
-//! use serde_json::{Map, to_value};
+//! use serde_json::{to_value, Map};
 //!
 //! let mut properties = Map::new();
-//! properties.insert(
-//!     String::from("name"),
-//!     to_value("Firestone Grill").unwrap(),
-//! );
+//! properties.insert(String::from("name"), to_value("Firestone Grill").unwrap());
 //! ```
 //!
 //! `GeoJson` can then be serialized by calling `to_string`:
@@ -105,16 +102,14 @@
 //! # fn main() {
 //! # let properties = properties();
 //!
-//! let geometry = Geometry::new(
-//!     Value::Point(vec![-120.66029,35.2812])
-//! );
+//! let geometry = Geometry::new(Value::Point(vec![-120.66029, 35.2812]));
 //!
 //! let geojson = GeoJson::Feature(Feature {
 //!     bbox: None,
 //!     geometry: Some(geometry),
 //!     id: None,
 //!     properties: Some(properties),
-//!     foreign_members: None
+//!     foreign_members: None,
 //! });
 //!
 //! let geojson_string = geojson.to_string();
@@ -138,11 +133,13 @@
 //! /// Process top-level GeoJSON items
 //! fn process_geojson(gj: &GeoJson) {
 //!     match *gj {
-//!         GeoJson::FeatureCollection(ref ctn) => for feature in &ctn.features {
-//!             if let Some(ref geom) = feature.geometry {
-//!                 match_geometry(geom)
+//!         GeoJson::FeatureCollection(ref ctn) => {
+//!             for feature in &ctn.features {
+//!                 if let Some(ref geom) = feature.geometry {
+//!                     match_geometry(geom)
+//!                 }
 //!             }
-//!         },
+//!         }
 //!         GeoJson::Feature(ref feature) => {
 //!             if let Some(ref geom) = feature.geometry {
 //!                 match_geometry(geom)
@@ -229,7 +226,7 @@
 //!
 //! ```
 //! # #[cfg(feature = "geo-types")]
-//! use geojson::{GeoJson, quick_collection};
+//! use geojson::{quick_collection, GeoJson};
 //! # #[cfg(feature = "geo-types")]
 //! use geo_types::GeometryCollection;
 //! # #[cfg(feature = "geo-types")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,7 +297,7 @@ mod feature_collection;
 pub use crate::feature_collection::FeatureCollection;
 
 mod errors;
-pub use crate::errors::GJError;
+pub use crate::errors::Error;
 
 #[cfg(feature = "geo-types")]
 mod conversion;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,7 +296,7 @@ pub mod feature;
 mod feature_collection;
 pub use crate::feature_collection::FeatureCollection;
 
-mod errors;
+pub mod errors;
 pub use crate::errors::Error;
 
 #[cfg(feature = "geo-types")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,6 +299,9 @@ pub mod feature;
 mod feature_collection;
 pub use crate::feature_collection::FeatureCollection;
 
+mod errors;
+pub use crate::errors::GJError;
+
 #[cfg(feature = "geo-types")]
 mod conversion;
 
@@ -330,131 +333,6 @@ pub struct Feature {
     ///
     /// [GeoJSON Format Specification § 6](https://tools.ietf.org/html/rfc7946#section-6)
     pub foreign_members: Option<json::JsonObject>,
-}
-
-/// Error when reading a GeoJSON object from a str or Object
-#[derive(Debug, PartialEq, Eq)]
-pub enum Error {
-    BboxExpectedArray,
-    BboxExpectedNumericValues,
-    GeoJsonExpectedObject,
-    GeoJsonUnknownType,
-    GeometryUnknownType,
-    MalformedJson,
-    PropertiesExpectedObjectOrNull,
-    FeatureInvalidGeometryValue,
-    FeatureInvalidIdentifierType,
-    ExpectedType { expected: String, actual: String },
-
-    // FIXME: make these types more specific
-    ExpectedStringValue,
-    ExpectedProperty(String),
-    ExpectedF64Value,
-    ExpectedArrayValue,
-    ExpectedObjectValue,
-}
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match *self {
-            Error::BboxExpectedArray =>
-            // FIXME: inform what type we actually found
-            {
-                write!(f, "Encountered non-array type for a 'bbox' object.")
-            }
-            Error::BboxExpectedNumericValues =>
-            // FIXME: inform what type we actually found
-            {
-                write!(f, "Encountered non-numeric value within 'bbox' array.")
-            }
-            Error::GeoJsonExpectedObject =>
-            // FIXME: inform what type we actually found
-            {
-                write!(f, "Encountered non-object type for GeoJSON.")
-            }
-            Error::GeoJsonUnknownType =>
-            // FIXME: inform what type we actually found
-            {
-                write!(f, "Encountered unknown GeoJSON object type.")
-            }
-            Error::GeometryUnknownType => write!(f, "Encountered unknown 'geometry' object type."),
-            Error::MalformedJson =>
-            // FIXME: can we report specific serialization error?
-            {
-                write!(f, "Encountered malformed JSON.")
-            }
-            Error::PropertiesExpectedObjectOrNull =>
-            // FIXME: inform what type we actually found
-            {
-                write!(
-                    f,
-                    "Encountered neither object type nor null type for \
-                     'properties' object."
-                )
-            }
-            Error::FeatureInvalidGeometryValue =>
-            // FIXME: inform what type we actually found
-            {
-                write!(
-                    f,
-                    "Encountered neither object type nor null type for \
-                     'geometry' field on 'feature' object."
-                )
-            }
-            Error::FeatureInvalidIdentifierType =>
-            // FIXME: inform what type we actually found
-            {
-                write!(
-                    f,
-                    "Encountered neither number type nor string type for \
-                     'id' field on 'feature' object."
-                )
-            }
-            Error::ExpectedType {
-                ref expected,
-                ref actual,
-            } => write!(
-                f,
-                "Expected GeoJSON type '{}', found '{}'",
-                expected, actual,
-            ),
-            Error::ExpectedStringValue => write!(f, "Expected a string value."),
-            Error::ExpectedProperty(ref prop_name) => {
-                write!(f, "Expected GeoJSON property '{}'.", prop_name)
-            }
-            Error::ExpectedF64Value => write!(f, "Expected a floating-point value."),
-            Error::ExpectedArrayValue => write!(f, "Expected an array."),
-            Error::ExpectedObjectValue => write!(f, "Expected an object."),
-        }
-    }
-}
-
-impl std::error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::BboxExpectedArray => "non-array 'bbox' type",
-            Error::BboxExpectedNumericValues => "non-numeric 'bbox' array",
-            Error::GeoJsonExpectedObject => "non-object GeoJSON type",
-            Error::GeoJsonUnknownType => "unknown GeoJSON object type",
-            Error::GeometryUnknownType => "unknown 'geometry' object type",
-            Error::MalformedJson => "malformed JSON",
-            Error::PropertiesExpectedObjectOrNull => {
-                "neither object type nor null type for properties' object."
-            }
-            Error::FeatureInvalidGeometryValue => {
-                "neither object type nor null type for 'geometry' field on 'feature' object."
-            }
-            Error::FeatureInvalidIdentifierType => {
-                "neither number type nor string type for 'id' field on 'feature' object."
-            }
-            Error::ExpectedType { .. } => "mismatched GeoJSON type",
-            Error::ExpectedStringValue => "expected a string value",
-            Error::ExpectedProperty(..) => "expected a GeoJSON property",
-            Error::ExpectedF64Value => "expected a floating-point value",
-            Error::ExpectedArrayValue => "expected an array",
-            Error::ExpectedObjectValue => "expected an object",
-        }
-    }
 }
 
 mod json {

--- a/src/util.rs
+++ b/src/util.rs
@@ -38,7 +38,7 @@ pub fn expect_f64(value: &JsonValue) -> Result<f64, Error> {
 pub fn expect_array(value: &JsonValue) -> Result<&Vec<JsonValue>, Error> {
     match value.as_array() {
         Some(v) => Ok(v),
-        None => Err(Error::ExpectedArrayValue),
+        None => Err(Error::ExpectedArrayValue("None".to_string())),
     }
 }
 
@@ -52,7 +52,15 @@ fn expect_property(obj: &mut JsonObject, name: &'static str) -> Result<JsonValue
 fn expect_owned_array(value: JsonValue) -> Result<Vec<JsonValue>, Error> {
     match value {
         JsonValue::Array(v) => Ok(v),
-        _ => Err(Error::ExpectedOwnedArrayValue(value)),
+        _ => match value {
+            // it can never be Array, but that's exhaustive matches for you
+            JsonValue::Array(_) => Err(Error::ExpectedArrayValue("Array".to_string())),
+            JsonValue::Null => Err(Error::ExpectedArrayValue("Null".to_string())),
+            JsonValue::Bool(_) => Err(Error::ExpectedArrayValue("Bool".to_string())),
+            JsonValue::Number(_) => Err(Error::ExpectedArrayValue("Number".to_string())),
+            JsonValue::String(_) => Err(Error::ExpectedArrayValue("String".to_string())),
+            JsonValue::Object(_) => Err(Error::ExpectedArrayValue("Object".to_string())),
+        },
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -24,7 +24,7 @@ pub fn expect_type(value: &mut JsonObject) -> Result<String, GJError> {
 pub fn expect_string(value: JsonValue) -> Result<String, GJError> {
     match value {
         JsonValue::String(s) => Ok(s),
-        _ => Err(GJError::ExpectedStringValue),
+        _ => Err(GJError::ExpectedStringValue(value)),
     }
 }
 
@@ -52,14 +52,14 @@ fn expect_property(obj: &mut JsonObject, name: &'static str) -> Result<JsonValue
 fn expect_owned_array(value: JsonValue) -> Result<Vec<JsonValue>, GJError> {
     match value {
         JsonValue::Array(v) => Ok(v),
-        _ => Err(GJError::ExpectedArrayValue),
+        _ => Err(GJError::ExpectedOwnedArrayValue(value)),
     }
 }
 
 fn expect_owned_object(value: JsonValue) -> Result<JsonObject, GJError> {
     match value {
         JsonValue::Object(o) => Ok(o),
-        _ => Err(GJError::ExpectedObjectValue),
+        _ => Err(GJError::ExpectedObjectValue(value)),
     }
 }
 
@@ -75,11 +75,12 @@ pub fn get_bbox(object: &mut JsonObject) -> Result<Option<Bbox>, GJError> {
     };
     let bbox_array = match bbox_json {
         JsonValue::Array(a) => a,
-        _ => return Err(GJError::BboxExpectedArray),
+        _ => return Err(GJError::BboxExpectedArray(bbox_json)),
+
     };
     let bbox = bbox_array
         .into_iter()
-        .map(|i| i.as_f64().ok_or(GJError::BboxExpectedNumericValues))
+        .map(|i| i.as_f64().ok_or(GJError::BboxExpectedNumericValues(i)))
         .collect::<Result<Vec<_>, _>>()?;
     Ok(Some(bbox))
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::errors::GJError;
 use crate::json::{JsonObject, JsonValue};
 use crate::{feature, Bbox, Feature, Geometry, Position};
-use crate::errors::GJError;
 
 pub fn expect_type(value: &mut JsonObject) -> Result<String, GJError> {
     let prop = expect_property(value, "type")?;

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,81 +12,81 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::errors::GJError;
+use crate::errors::Error;
 use crate::json::{JsonObject, JsonValue};
 use crate::{feature, Bbox, Feature, Geometry, Position};
 
-pub fn expect_type(value: &mut JsonObject) -> Result<String, GJError> {
+pub fn expect_type(value: &mut JsonObject) -> Result<String, Error> {
     let prop = expect_property(value, "type")?;
     expect_string(prop)
 }
 
-pub fn expect_string(value: JsonValue) -> Result<String, GJError> {
+pub fn expect_string(value: JsonValue) -> Result<String, Error> {
     match value {
         JsonValue::String(s) => Ok(s),
-        _ => Err(GJError::ExpectedStringValue(value)),
+        _ => Err(Error::ExpectedStringValue(value)),
     }
 }
 
-pub fn expect_f64(value: &JsonValue) -> Result<f64, GJError> {
+pub fn expect_f64(value: &JsonValue) -> Result<f64, Error> {
     match value.as_f64() {
         Some(v) => Ok(v),
-        None => Err(GJError::ExpectedF64Value),
+        None => Err(Error::ExpectedF64Value),
     }
 }
 
-pub fn expect_array(value: &JsonValue) -> Result<&Vec<JsonValue>, GJError> {
+pub fn expect_array(value: &JsonValue) -> Result<&Vec<JsonValue>, Error> {
     match value.as_array() {
         Some(v) => Ok(v),
-        None => Err(GJError::ExpectedArrayValue),
+        None => Err(Error::ExpectedArrayValue),
     }
 }
 
-fn expect_property(obj: &mut JsonObject, name: &'static str) -> Result<JsonValue, GJError> {
+fn expect_property(obj: &mut JsonObject, name: &'static str) -> Result<JsonValue, Error> {
     match obj.remove(name) {
         Some(v) => Ok(v),
-        None => Err(GJError::ExpectedProperty(name.to_string())),
+        None => Err(Error::ExpectedProperty(name.to_string())),
     }
 }
 
-fn expect_owned_array(value: JsonValue) -> Result<Vec<JsonValue>, GJError> {
+fn expect_owned_array(value: JsonValue) -> Result<Vec<JsonValue>, Error> {
     match value {
         JsonValue::Array(v) => Ok(v),
-        _ => Err(GJError::ExpectedOwnedArrayValue(value)),
+        _ => Err(Error::ExpectedOwnedArrayValue(value)),
     }
 }
 
-fn expect_owned_object(value: JsonValue) -> Result<JsonObject, GJError> {
+fn expect_owned_object(value: JsonValue) -> Result<JsonObject, Error> {
     match value {
         JsonValue::Object(o) => Ok(o),
-        _ => Err(GJError::ExpectedObjectValue(value)),
+        _ => Err(Error::ExpectedObjectValue(value)),
     }
 }
 
-pub fn get_coords_value(object: &mut JsonObject) -> Result<JsonValue, GJError> {
+pub fn get_coords_value(object: &mut JsonObject) -> Result<JsonValue, Error> {
     expect_property(object, "coordinates")
 }
 
 /// Used by FeatureCollection, Feature, Geometry
-pub fn get_bbox(object: &mut JsonObject) -> Result<Option<Bbox>, GJError> {
+pub fn get_bbox(object: &mut JsonObject) -> Result<Option<Bbox>, Error> {
     let bbox_json = match object.remove("bbox") {
         Some(b) => b,
         None => return Ok(None),
     };
     let bbox_array = match bbox_json {
         JsonValue::Array(a) => a,
-        _ => return Err(GJError::BboxExpectedArray(bbox_json)),
+        _ => return Err(Error::BboxExpectedArray(bbox_json)),
 
     };
     let bbox = bbox_array
         .into_iter()
-        .map(|i| i.as_f64().ok_or(GJError::BboxExpectedNumericValues(i)))
+        .map(|i| i.as_f64().ok_or(Error::BboxExpectedNumericValues(i)))
         .collect::<Result<Vec<_>, _>>()?;
     Ok(Some(bbox))
 }
 
 /// Used by FeatureCollection, Feature, Geometry
-pub fn get_foreign_members(object: JsonObject) -> Result<Option<JsonObject>, GJError> {
+pub fn get_foreign_members(object: JsonObject) -> Result<Option<JsonObject>, Error> {
     if object.is_empty() {
         Ok(None)
     } else {
@@ -95,19 +95,19 @@ pub fn get_foreign_members(object: JsonObject) -> Result<Option<JsonObject>, GJE
 }
 
 /// Used by Feature
-pub fn get_properties(object: &mut JsonObject) -> Result<Option<JsonObject>, GJError> {
+pub fn get_properties(object: &mut JsonObject) -> Result<Option<JsonObject>, Error> {
     let properties = expect_property(object, "properties")?;
     match properties {
         JsonValue::Object(x) => Ok(Some(x)),
         JsonValue::Null => Ok(None),
-        _ => Err(GJError::PropertiesExpectedObjectOrNull(properties)),
+        _ => Err(Error::PropertiesExpectedObjectOrNull(properties)),
     }
 }
 
 /// Retrieve a single Position from the value of the "coordinates" key
 ///
 /// Used by Value::Point
-pub fn get_coords_one_pos(object: &mut JsonObject) -> Result<Position, GJError> {
+pub fn get_coords_one_pos(object: &mut JsonObject) -> Result<Position, Error> {
     let coords_json = get_coords_value(object)?;
     json_to_position(&coords_json)
 }
@@ -115,7 +115,7 @@ pub fn get_coords_one_pos(object: &mut JsonObject) -> Result<Position, GJError> 
 /// Retrieve a one dimensional Vec of Positions from the value of the "coordinates" key
 ///
 /// Used by Value::MultiPoint and Value::LineString
-pub fn get_coords_1d_pos(object: &mut JsonObject) -> Result<Vec<Position>, GJError> {
+pub fn get_coords_1d_pos(object: &mut JsonObject) -> Result<Vec<Position>, Error> {
     let coords_json = get_coords_value(object)?;
     json_to_1d_positions(&coords_json)
 }
@@ -123,7 +123,7 @@ pub fn get_coords_1d_pos(object: &mut JsonObject) -> Result<Vec<Position>, GJErr
 /// Retrieve a two dimensional Vec of Positions from the value of the "coordinates" key
 ///
 /// Used by Value::MultiLineString and Value::Polygon
-pub fn get_coords_2d_pos(object: &mut JsonObject) -> Result<Vec<Vec<Position>>, GJError> {
+pub fn get_coords_2d_pos(object: &mut JsonObject) -> Result<Vec<Vec<Position>>, Error> {
     let coords_json = get_coords_value(object)?;
     json_to_2d_positions(&coords_json)
 }
@@ -131,13 +131,13 @@ pub fn get_coords_2d_pos(object: &mut JsonObject) -> Result<Vec<Vec<Position>>, 
 /// Retrieve a three dimensional Vec of Positions from the value of the "coordinates" key
 ///
 /// Used by Value::MultiPolygon
-pub fn get_coords_3d_pos(object: &mut JsonObject) -> Result<Vec<Vec<Vec<Position>>>, GJError> {
+pub fn get_coords_3d_pos(object: &mut JsonObject) -> Result<Vec<Vec<Vec<Position>>>, Error> {
     let coords_json = get_coords_value(object)?;
     json_to_3d_positions(&coords_json)
 }
 
 /// Used by Value::GeometryCollection
-pub fn get_geometries(object: &mut JsonObject) -> Result<Vec<Geometry>, GJError> {
+pub fn get_geometries(object: &mut JsonObject) -> Result<Vec<Geometry>, Error> {
     let geometries_json = expect_property(object, "geometries")?;
     let geometries_array = expect_owned_array(geometries_json)?;
     let mut geometries = Vec::with_capacity(geometries_array.len());
@@ -150,17 +150,17 @@ pub fn get_geometries(object: &mut JsonObject) -> Result<Vec<Geometry>, GJError>
 }
 
 /// Used by Feature
-pub fn get_id(object: &mut JsonObject) -> Result<Option<feature::Id>, GJError> {
+pub fn get_id(object: &mut JsonObject) -> Result<Option<feature::Id>, Error> {
     match object.remove("id") {
         Some(JsonValue::Number(x)) => Ok(Some(feature::Id::Number(x))),
         Some(JsonValue::String(s)) => Ok(Some(feature::Id::String(s))),
-        Some(v) => Err(GJError::FeatureInvalidIdentifierType(v)),
+        Some(v) => Err(Error::FeatureInvalidIdentifierType(v)),
         None => Ok(None),
     }
 }
 
 /// Used by Feature
-pub fn get_geometry(object: &mut JsonObject) -> Result<Option<Geometry>, GJError> {
+pub fn get_geometry(object: &mut JsonObject) -> Result<Option<Geometry>, Error> {
     let geometry = expect_property(object, "geometry")?;
     match geometry {
         JsonValue::Object(x) => {
@@ -168,12 +168,12 @@ pub fn get_geometry(object: &mut JsonObject) -> Result<Option<Geometry>, GJError
             Ok(Some(geometry_object))
         }
         JsonValue::Null => Ok(None),
-        _ => Err(GJError::FeatureInvalidGeometryValue(geometry)),
+        _ => Err(Error::FeatureInvalidGeometryValue(geometry)),
     }
 }
 
 /// Used by FeatureCollection
-pub fn get_features(object: &mut JsonObject) -> Result<Vec<Feature>, GJError> {
+pub fn get_features(object: &mut JsonObject) -> Result<Vec<Feature>, Error> {
     let prop = expect_property(object, "features")?;
     let features_json = expect_owned_array(prop)?;
     let mut features = Vec::with_capacity(features_json.len());
@@ -185,7 +185,7 @@ pub fn get_features(object: &mut JsonObject) -> Result<Vec<Feature>, GJError> {
     Ok(features)
 }
 
-fn json_to_position(json: &JsonValue) -> Result<Position, GJError> {
+fn json_to_position(json: &JsonValue) -> Result<Position, Error> {
     let coords_array = expect_array(json)?;
     let mut coords = Vec::with_capacity(coords_array.len());
     for position in coords_array {
@@ -194,7 +194,7 @@ fn json_to_position(json: &JsonValue) -> Result<Position, GJError> {
     Ok(coords)
 }
 
-fn json_to_1d_positions(json: &JsonValue) -> Result<Vec<Position>, GJError> {
+fn json_to_1d_positions(json: &JsonValue) -> Result<Vec<Position>, Error> {
     let coords_array = expect_array(json)?;
     let mut coords = Vec::with_capacity(coords_array.len());
     for item in coords_array {
@@ -203,7 +203,7 @@ fn json_to_1d_positions(json: &JsonValue) -> Result<Vec<Position>, GJError> {
     Ok(coords)
 }
 
-fn json_to_2d_positions(json: &JsonValue) -> Result<Vec<Vec<Position>>, GJError> {
+fn json_to_2d_positions(json: &JsonValue) -> Result<Vec<Vec<Position>>, Error> {
     let coords_array = expect_array(json)?;
     let mut coords = Vec::with_capacity(coords_array.len());
     for item in coords_array {
@@ -212,7 +212,7 @@ fn json_to_2d_positions(json: &JsonValue) -> Result<Vec<Vec<Position>>, GJError>
     Ok(coords)
 }
 
-fn json_to_3d_positions(json: &JsonValue) -> Result<Vec<Vec<Vec<Position>>>, GJError> {
+fn json_to_3d_positions(json: &JsonValue) -> Result<Vec<Vec<Vec<Position>>>, Error> {
     let coords_array = expect_array(json)?;
     let mut coords = Vec::with_capacity(coords_array.len());
     for item in coords_array {

--- a/src/util.rs
+++ b/src/util.rs
@@ -76,7 +76,6 @@ pub fn get_bbox(object: &mut JsonObject) -> Result<Option<Bbox>, Error> {
     let bbox_array = match bbox_json {
         JsonValue::Array(a) => a,
         _ => return Err(Error::BboxExpectedArray(bbox_json)),
-
     };
     let bbox = bbox_array
         .into_iter()

--- a/src/util.rs
+++ b/src/util.rs
@@ -153,7 +153,7 @@ pub fn get_id(object: &mut JsonObject) -> Result<Option<feature::Id>, GJError> {
     match object.remove("id") {
         Some(JsonValue::Number(x)) => Ok(Some(feature::Id::Number(x))),
         Some(JsonValue::String(s)) => Ok(Some(feature::Id::String(s))),
-        Some(_) => Err(GJError::FeatureInvalidIdentifierType),
+        Some(v) => Err(GJError::FeatureInvalidIdentifierType(v)),
         None => Ok(None),
     }
 }


### PR DESCRIPTION
This PR:

- Switches to `thiserror`, removing the need for manual trait impls and definitions
- Adds several more granular errors where appropriate
- Returns the `Value` causing the error where possible in order to add context

`thiserror` is an additional dependency, but it's not part of the public API and we already depend on `syn` etc due to `serde`, so compile times aren't greatly affected.

**this is a breaking API change due to the addition of new errors**