### PR TITLE
rename misleading variable. No change in behavior.

### DIFF
--- a/src/conversion/from_geo_types.rs
+++ b/src/conversion/from_geo_types.rs
@@ -88,13 +88,13 @@ where
     T: Float,
 {
     fn from(geometry_collection: &geo_types::GeometryCollection<T>) -> Self {
-        let coords = geometry_collection
+        let values = geometry_collection
             .0
             .iter()
             .map(|geometry| geometry::Geometry::new(geometry::Value::from(geometry)))
             .collect();
 
-        geometry::Value::GeometryCollection(coords)
+        geometry::Value::GeometryCollection(values)
     }
 }
 


### PR DESCRIPTION
I think `coords` was copied from similar impls which deal with coordinates. It confused me.