### PR TITLE
Improve Value docs with more info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "geojson"
 description = "Library for serializing the GeoJSON vector GIS file format"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["The GeoRust Developers <mods@georust.org>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/georust/geojson"

--- a/src/conversion/from_geo_types.rs
+++ b/src/conversion/from_geo_types.rs
@@ -139,6 +139,7 @@ impl<'a, T> From<&'a geo_types::Geometry<T>> for geometry::Value
 where
     T: Float,
 {
+    /// Convert from `geo_types::Geometry` enums
     fn from(geometry: &'a geo_types::Geometry<T>) -> Self {
         match *geometry {
             geo_types::Geometry::Point(ref point) => geometry::Value::from(point),

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -23,15 +23,20 @@ use crate::{util, Bbox, LineStringType, PointType, PolygonType};
 ///
 /// # Conversion from `geo_types`
 ///
-/// `From` is implemented for `Value` for converting from `geo_types` geospatial
-/// types:
+/// A `Value` can be created by using the `From` impl which is available for both `geo_types`
+/// primitives AND `geo_types::Geometry` enum members:
 ///
 /// ```rust
 /// # #[cfg(feature = "geo-types")]
 /// # fn test() {
 /// let point = geo_types::Point::new(2., 9.);
+/// let genum = geo_types::Geometry::from(point);
 /// assert_eq!(
 ///     geojson::Value::from(&point),
+///     geojson::Value::Point(vec![2., 9.]),
+/// );
+/// assert_eq!(
+///     geojson::Value::from(&genum),
 ///     geojson::Value::Point(vec![2., 9.]),
 /// );
 /// # }
@@ -121,7 +126,7 @@ impl Serialize for Value {
 /// let geometry = Geometry::new(Value::Point(vec![7.428959, 1.513394]));
 /// ```
 ///
-/// Geometries can be created from Values.
+/// Geometries can be created from `Value`s.
 /// ```
 /// # use geojson::{Geometry, Value};
 /// let geometry1: Geometry = Value::Point(vec![7.428959, 1.513394]).into();
@@ -290,7 +295,8 @@ impl<'de> Deserialize<'de> for Geometry {
 }
 
 impl<V> From<V> for Geometry
-    where V: Into<Value>
+where
+    V: Into<Value>,
 {
     fn from(v: V) -> Geometry {
         Geometry::new(v.into())


### PR DESCRIPTION
Now shows that both `geo_types` primitives AND `geo_types::Geometry` enum
members can be converted to `Value` using `From`