### PR TITLE
Display GeoJSON string for geojson::Value

### DIFF
--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -84,7 +84,7 @@ pub enum Value {
 
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{}", Geometry::new(self.clone()))
     }
 }
 
@@ -368,6 +368,15 @@ mod tests {
         assert_eq!(
             "{\"coordinates\":[[0.0,0.1],[0.1,0.2],[0.2,0.3]],\"type\":\"LineString\"}",
             geometry.to_string()
+        );
+    }
+
+    #[test]
+    fn test_value_display() {
+        let v = Value::LineString(vec![vec![0.0, 0.1], vec![0.1, 0.2], vec![0.2, 0.3]]);
+        assert_eq!(
+            "{\"coordinates\":[[0.0,0.1],[0.1,0.2],[0.2,0.3]],\"type\":\"LineString\"}",
+            v.to_string()
         );
     }
 

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -108,6 +108,36 @@ impl<'a> From<&'a Value> for JsonObject {
     }
 }
 
+impl Value {
+    pub fn from_json_object(object: JsonObject) -> Result<Self, Error> {
+        Self::try_from(object)
+    }
+
+    pub fn from_json_value(value: JsonValue) -> Result<Self, Error> {
+        Self::try_from(value)
+    }
+}
+
+impl TryFrom<JsonObject> for Value {
+    type Error = Error;
+
+    fn try_from(mut object: JsonObject) -> Result<Self, Self::Error> {
+        util::get_value(&mut object)
+    }
+}
+
+impl TryFrom<JsonValue> for Value {
+    type Error = Error;
+
+    fn try_from(value: JsonValue) -> Result<Self, Self::Error> {
+        if let JsonValue::Object(obj) = value {
+            Self::try_from(obj)
+        } else {
+            Err(Error::GeoJsonExpectedObject(value))
+        }
+    }
+}
+
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         ::serde_json::to_string(&JsonObject::from(self))
@@ -248,18 +278,8 @@ impl TryFrom<JsonObject> for Geometry {
     type Error = Error;
 
     fn try_from(mut object: JsonObject) -> Result<Self, Self::Error> {
-        let res = &*util::expect_type(&mut object)?;
-        let value = match res {
-            "Point" => Value::Point(util::get_coords_one_pos(&mut object)?),
-            "MultiPoint" => Value::MultiPoint(util::get_coords_1d_pos(&mut object)?),
-            "LineString" => Value::LineString(util::get_coords_1d_pos(&mut object)?),
-            "MultiLineString" => Value::MultiLineString(util::get_coords_2d_pos(&mut object)?),
-            "Polygon" => Value::Polygon(util::get_coords_2d_pos(&mut object)?),
-            "MultiPolygon" => Value::MultiPolygon(util::get_coords_3d_pos(&mut object)?),
-            "GeometryCollection" => Value::GeometryCollection(util::get_geometries(&mut object)?),
-            _ => return Err(Error::GeometryUnknownType(res.to_string())),
-        };
         let bbox = util::get_bbox(&mut object)?;
+        let value = util::get_value(&mut object)?;
         let foreign_members = util::get_foreign_members(object)?;
         Ok(Geometry {
             bbox,


### PR DESCRIPTION
Closes #149. Uses the existing `Display` implementation on `Geometry` to display the GeoJSON string for `geojson::Value`.

The issue mentions needing to wrap the `Value` in both a `Geometry` and `GeoJson`, but I'm only wrapping in a `Geometry` here so let me know if I missed anything. I'm also not sure if there's a clean way of avoiding the `clone()` when creating the `Geometry`. Happy to make any changes, thanks!