### PR TITLE
update geo-types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ edition = "2018"
 [dependencies]
 serde = "~1.0"
 serde_json = "~1.0"
-geo-types = { version = "0.6", optional = true }
-num-traits = "0.2"
+geo-types = { version = "0.7", optional = true }
 thiserror = "1.0.20"
 
 [dev-dependencies]
+num-traits = "0.2"
 criterion = "0.3"
 
 [[bench]]
@@ -31,3 +31,4 @@ harness = false
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+

--- a/src/conversion/from_geo_types.rs
+++ b/src/conversion/from_geo_types.rs
@@ -1,15 +1,14 @@
-use crate::geo_types;
+use crate::geo_types::{self, CoordFloat};
 
 use crate::geometry;
 
 use crate::{LineStringType, PointType, PolygonType};
-use num_traits::Float;
 use std::convert::From;
 
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<'a, T> From<&'a geo_types::Point<T>> for geometry::Value
 where
-    T: Float,
+    T: CoordFloat,
 {
     fn from(point: &geo_types::Point<T>) -> Self {
         let coords = create_point_type(point);
@@ -21,7 +20,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<'a, T> From<&'a geo_types::MultiPoint<T>> for geometry::Value
 where
-    T: Float,
+    T: CoordFloat,
 {
     fn from(multi_point: &geo_types::MultiPoint<T>) -> Self {
         let coords = multi_point
@@ -37,7 +36,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<'a, T> From<&'a geo_types::LineString<T>> for geometry::Value
 where
-    T: Float,
+    T: CoordFloat,
 {
     fn from(line_string: &geo_types::LineString<T>) -> Self {
         let coords = create_line_string_type(line_string);
@@ -49,7 +48,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<'a, T> From<&'a geo_types::Line<T>> for geometry::Value
 where
-    T: Float,
+    T: CoordFloat,
 {
     fn from(line: &geo_types::Line<T>) -> Self {
         let coords = create_from_line_type(line);
@@ -61,7 +60,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<'a, T> From<&'a geo_types::Triangle<T>> for geometry::Value
 where
-    T: Float,
+    T: CoordFloat,
 {
     fn from(triangle: &geo_types::Triangle<T>) -> Self {
         let coords = create_from_triangle_type(triangle);
@@ -73,7 +72,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<'a, T> From<&'a geo_types::Rect<T>> for geometry::Value
 where
-    T: Float,
+    T: CoordFloat,
 {
     fn from(rect: &geo_types::Rect<T>) -> Self {
         let coords = create_from_rect_type(rect);
@@ -85,7 +84,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<'a, T> From<&'a geo_types::MultiLineString<T>> for geometry::Value
 where
-    T: Float,
+    T: CoordFloat,
 {
     fn from(multi_line_string: &geo_types::MultiLineString<T>) -> Self {
         let coords = create_multi_line_string_type(multi_line_string);
@@ -97,7 +96,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<'a, T> From<&'a geo_types::Polygon<T>> for geometry::Value
 where
-    T: Float,
+    T: CoordFloat,
 {
     fn from(polygon: &geo_types::Polygon<T>) -> Self {
         let coords = create_polygon_type(polygon);
@@ -109,7 +108,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<'a, T> From<&'a geo_types::MultiPolygon<T>> for geometry::Value
 where
-    T: Float,
+    T: CoordFloat,
 {
     fn from(multi_polygon: &geo_types::MultiPolygon<T>) -> Self {
         let coords = create_multi_polygon_type(multi_polygon);
@@ -121,7 +120,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<'a, T> From<&'a geo_types::GeometryCollection<T>> for geometry::Value
 where
-    T: Float,
+    T: CoordFloat,
 {
     fn from(geometry_collection: &geo_types::GeometryCollection<T>) -> Self {
         let values = geometry_collection
@@ -137,7 +136,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<'a, T> From<&'a geo_types::Geometry<T>> for geometry::Value
 where
-    T: Float,
+    T: CoordFloat,
 {
     /// Convert from `geo_types::Geometry` enums
     fn from(geometry: &'a geo_types::Geometry<T>) -> Self {
@@ -162,7 +161,7 @@ where
 
 fn create_point_type<T>(point: &geo_types::Point<T>) -> PointType
 where
-    T: Float,
+    T: CoordFloat,
 {
     let x: f64 = point.x().to_f64().unwrap();
     let y: f64 = point.y().to_f64().unwrap();
@@ -172,7 +171,7 @@ where
 
 fn create_line_string_type<T>(line_string: &geo_types::LineString<T>) -> LineStringType
 where
-    T: Float,
+    T: CoordFloat,
 {
     line_string
         .points_iter()
@@ -182,7 +181,7 @@ where
 
 fn create_from_line_type<T>(line_string: &geo_types::Line<T>) -> LineStringType
 where
-    T: Float,
+    T: CoordFloat,
 {
     vec![
         create_point_type(&line_string.start_point()),
@@ -192,14 +191,14 @@ where
 
 fn create_from_triangle_type<T>(triangle: &geo_types::Triangle<T>) -> PolygonType
 where
-    T: Float,
+    T: CoordFloat,
 {
     create_polygon_type(&triangle.to_polygon())
 }
 
 fn create_from_rect_type<T>(rect: &geo_types::Rect<T>) -> PolygonType
 where
-    T: Float,
+    T: CoordFloat,
 {
     create_polygon_type(&rect.to_polygon())
 }
@@ -208,7 +207,7 @@ fn create_multi_line_string_type<T>(
     multi_line_string: &geo_types::MultiLineString<T>,
 ) -> Vec<LineStringType>
 where
-    T: Float,
+    T: CoordFloat,
 {
     multi_line_string
         .0
@@ -219,7 +218,7 @@ where
 
 fn create_polygon_type<T>(polygon: &geo_types::Polygon<T>) -> PolygonType
 where
-    T: Float,
+    T: CoordFloat,
 {
     let mut coords = vec![polygon
         .exterior()
@@ -239,7 +238,7 @@ where
 
 fn create_multi_polygon_type<T>(multi_polygon: &geo_types::MultiPolygon<T>) -> Vec<PolygonType>
 where
-    T: Float,
+    T: CoordFloat,
 {
     multi_polygon
         .0

--- a/src/conversion/mod.rs
+++ b/src/conversion/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::geo_types;
+use crate::geo_types::{self, CoordFloat};
 use crate::geo_types::{
     Geometry as GtGeometry, GeometryCollection, LineString as GtLineString,
     MultiLineString as GtMultiLineString, MultiPoint as GtMultiPoint,
@@ -24,7 +24,6 @@ use crate::geojson::GeoJson::{Feature, FeatureCollection, Geometry};
 use crate::geometry::Geometry as GjGeometry;
 use crate::Error as GJError;
 use crate::Value;
-use num_traits::Float;
 use std::convert::TryInto;
 
 #[cfg(test)]
@@ -76,7 +75,7 @@ pub(crate) mod to_geo_types;
 // Process top-level `GeoJSON` items, returning a geo_types::GeometryCollection or an Error
 fn process_geojson<T>(gj: &GeoJson) -> Result<geo_types::GeometryCollection<T>, GJError>
 where
-    T: Float,
+    T: CoordFloat,
 {
     match &*gj {
         FeatureCollection(collection) => Ok(GeometryCollection(
@@ -102,7 +101,7 @@ where
 // Process GeoJson Geometry objects, returning their geo_types equivalents, or an error
 fn process_geometry<T>(geometry: &GjGeometry) -> Result<geo_types::Geometry<T>, GJError>
 where
-    T: Float,
+    T: CoordFloat,
 {
     match &geometry.value {
         Value::Point(_) => Ok(TryInto::<GtPoint<_>>::try_into(geometry.value.clone())?.into()),
@@ -166,7 +165,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 pub fn quick_collection<T>(gj: &GeoJson) -> Result<geo_types::GeometryCollection<T>, GJError>
 where
-    T: Float,
+    T: CoordFloat,
 {
     process_geojson(gj)
 }

--- a/src/conversion/to_geo_types.rs
+++ b/src/conversion/to_geo_types.rs
@@ -1,4 +1,4 @@
-use crate::geo_types;
+use crate::geo_types::{self, CoordFloat};
 
 use crate::geometry;
 
@@ -7,13 +7,12 @@ use crate::{
     quick_collection, Feature, FeatureCollection, GeoJson, Geometry, LineStringType, PointType,
     PolygonType,
 };
-use num_traits::Float;
 use std::convert::{TryFrom, TryInto};
 
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<T> TryFrom<geometry::Value> for geo_types::Point<T>
 where
-    T: Float,
+    T: CoordFloat,
 {
     type Error = GJError;
 
@@ -28,7 +27,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<T> TryFrom<geometry::Value> for geo_types::MultiPoint<T>
 where
-    T: Float,
+    T: CoordFloat,
 {
     type Error = GJError;
 
@@ -48,7 +47,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<T> TryFrom<geometry::Value> for geo_types::LineString<T>
 where
-    T: Float,
+    T: CoordFloat,
 {
     type Error = GJError;
 
@@ -65,7 +64,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<T> TryFrom<geometry::Value> for geo_types::MultiLineString<T>
 where
-    T: Float,
+    T: CoordFloat,
 {
     type Error = GJError;
 
@@ -82,7 +81,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<T> TryFrom<geometry::Value> for geo_types::Polygon<T>
 where
-    T: Float,
+    T: CoordFloat,
 {
     type Error = GJError;
 
@@ -97,7 +96,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<T> TryFrom<geometry::Value> for geo_types::MultiPolygon<T>
 where
-    T: Float,
+    T: CoordFloat,
 {
     type Error = GJError;
 
@@ -114,7 +113,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<T> TryFrom<geometry::Value> for geo_types::GeometryCollection<T>
 where
-    T: Float,
+    T: CoordFloat,
 {
     type Error = GJError;
 
@@ -136,7 +135,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<T> TryFrom<geometry::Value> for geo_types::Geometry<T>
 where
-    T: Float,
+    T: CoordFloat,
 {
     type Error = GJError;
 
@@ -175,7 +174,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<T> TryFrom<Geometry> for geo_types::Geometry<T>
 where
-    T: Float,
+    T: CoordFloat,
 {
     type Error = GJError;
 
@@ -187,7 +186,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<T> TryFrom<Feature> for geo_types::Geometry<T>
 where
-    T: Float,
+    T: CoordFloat,
 {
     type Error = GJError;
 
@@ -202,7 +201,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<T> TryFrom<FeatureCollection> for geo_types::Geometry<T>
 where
-    T: Float,
+    T: CoordFloat,
 {
     type Error = GJError;
 
@@ -216,7 +215,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<T> TryFrom<GeoJson> for geo_types::Geometry<T>
 where
-    T: Float,
+    T: CoordFloat,
 {
     type Error = GJError;
 
@@ -231,7 +230,7 @@ where
 
 fn create_geo_coordinate<T>(point_type: &PointType) -> geo_types::Coordinate<T>
 where
-    T: Float,
+    T: CoordFloat,
 {
     geo_types::Coordinate {
         x: T::from(point_type[0]).unwrap(),
@@ -241,7 +240,7 @@ where
 
 fn create_geo_point<T>(point_type: &PointType) -> geo_types::Point<T>
 where
-    T: Float,
+    T: CoordFloat,
 {
     geo_types::Point::new(
         T::from(point_type[0]).unwrap(),
@@ -251,7 +250,7 @@ where
 
 fn create_geo_line_string<T>(line_type: &LineStringType) -> geo_types::LineString<T>
 where
-    T: Float,
+    T: CoordFloat,
 {
     geo_types::LineString(
         line_type
@@ -265,7 +264,7 @@ fn create_geo_multi_line_string<T>(
     multi_line_type: &[LineStringType],
 ) -> geo_types::MultiLineString<T>
 where
-    T: Float,
+    T: CoordFloat,
 {
     geo_types::MultiLineString(
         multi_line_type
@@ -277,7 +276,7 @@ where
 
 fn create_geo_polygon<T>(polygon_type: &PolygonType) -> geo_types::Polygon<T>
 where
-    T: Float,
+    T: CoordFloat,
 {
     let exterior = polygon_type
         .get(0)
@@ -298,7 +297,7 @@ where
 
 fn create_geo_multi_polygon<T>(multi_polygon_type: &[PolygonType]) -> geo_types::MultiPolygon<T>
 where
-    T: Float,
+    T: CoordFloat,
 {
     geo_types::MultiPolygon(
         multi_polygon_type


### PR DESCRIPTION
geo_types now require that Coordinates hold a CoordNum (or it's extension CoordFloat), which is also `Debug`.

also: `num_traits` is now only exposed in tests, so moved it to a devDependency.