### PR TITLE
Provide additional conversions from `Geometry` and `Value` to `Feature`

### DIFF
--- a/src/conversion/from_geo_types.rs
+++ b/src/conversion/from_geo_types.rs
@@ -1,6 +1,6 @@
 use crate::geo_types::{self, CoordFloat};
 
-use crate::geometry;
+use crate::{geometry, Feature, FeatureCollection};
 
 use crate::{LineStringType, PointType, PolygonType};
 use std::convert::From;
@@ -130,6 +130,26 @@ where
             .collect();
 
         geometry::Value::GeometryCollection(values)
+    }
+}
+
+#[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
+impl<'a, T> From<&'a geo_types::GeometryCollection<T>> for FeatureCollection
+where
+    T: CoordFloat,
+{
+    fn from(geometry_collection: &geo_types::GeometryCollection<T>) -> Self {
+        let values: Vec<Feature> = geometry_collection
+            .0
+            .iter()
+            .map(|geometry| geometry::Geometry::new(geometry::Value::from(geometry)).into())
+            .collect();
+
+        FeatureCollection {
+            bbox: None,
+            features: values,
+            foreign_members: None,
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,8 @@
 //!
 //! With `FeatureCollection` being the most commonly used, since it can contain multiple child objects.
 //! A `FeatureCollection` contains `Feature` objects, each of which contains a `Geometry` object, which may be empty.
+//! Since the most common uses cases for GeoJSON involve the use of `Feature` and `FeatureCollection` objects,
+//! conversions to `Feature` are provided for both `Value` enum members and Geometry objects via the `From` trait.
 //! A potentially complicating factor is the `GeometryCollection` geometry type, which can contain
 //! one more `Geometry` objects, _including nested `GeometryCollection` objects_.
 //! The use of `GeometryCollection` is discouraged, however.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@
 //! # #[cfg(feature = "geo-types")]
 //! let gc = GeometryCollection::from_iter(polys);
 //! # #[cfg(feature = "geo-types")]
-//! let fc = FeatureCollection::from(polys)
+//! let fc = FeatureCollection::from(polys);
 //! ```
 //!
 //! This crate uses `serde` for serialization.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,8 +40,30 @@
 //! a [`geo_types::GeometryCollection`](../geo_types/struct.GeometryCollection.html).
 //! See [here](#conversion-to-geo-objects) for details.
 //!
-//! Conversely, if you wish to produce a `FeatureCollection` from a collection of `geo` types, a `From` impl is
-//! provided for `&geo_types::GeometryCollection`.
+//! Conversely, if you wish to produce a `FeatureCollection` from a homogenous collection of `geo` types, a `From` impl is
+//! provided for `geo_types::GeometryCollection`:
+//!
+//! ```rust
+//! # #[cfg(feature = "geo-types")]
+//! use geo::{polygon, GeometryCollection};
+//! # #[cfg(feature = "geo-types")]
+//! use std::iter::FromIterator;
+//! 
+//! # #[cfg(feature = "geo-types")]
+//! let poly = polygon![
+//!     (x: -111., y: 45.),
+//!     (x: -111., y: 41.),
+//!     (x: -104., y: 41.),
+//!     (x: -104., y: 45.),
+//! ];
+//! 
+//! # #[cfg(feature = "geo-types")]
+//! let polys = vec![poly];
+//! # #[cfg(feature = "geo-types")]
+//! let gc = GeometryCollection::from_iter(polys);
+//! # #[cfg(feature = "geo-types")]
+//! let fc = FeatureCollection::from(polys)
+//! ```
 //!
 //! This crate uses `serde` for serialization.
 //! To get started, add `geojson` to your `Cargo.toml`:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,24 +45,24 @@
 //!
 //! ```rust
 //! # #[cfg(feature = "geo-types")]
-//! use geo::{polygon, GeometryCollection};
+//! use geojson::FeatureCollection;
+//! # #[cfg(feature = "geo-types")]
+//! use geo_types::{GeometryCollection, LineString, Polygon};
 //! # #[cfg(feature = "geo-types")]
 //! use std::iter::FromIterator;
 //! 
 //! # #[cfg(feature = "geo-types")]
-//! let poly = polygon![
-//!     (x: -111., y: 45.),
-//!     (x: -111., y: 41.),
-//!     (x: -104., y: 41.),
-//!     (x: -104., y: 45.),
-//! ];
+//! let poly = Polygon::new(
+//!    LineString::from(vec![(0., 0.), (1., 1.), (1., 0.), (0., 0.)]),
+//!    vec![],
+//! );
 //! 
 //! # #[cfg(feature = "geo-types")]
 //! let polys = vec![poly];
 //! # #[cfg(feature = "geo-types")]
 //! let gc = GeometryCollection::from_iter(polys);
 //! # #[cfg(feature = "geo-types")]
-//! let fc = FeatureCollection::from(polys);
+//! let fc = FeatureCollection::from(&gc);
 //! ```
 //!
 //! This crate uses `serde` for serialization.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,8 @@
 //!
 //! ```rust
 //! # #[cfg(feature = "geo-types")]
+//! // The geo-types feature is required for this functionality
+//! # #[cfg(feature = "geo-types")]
 //! use geojson::FeatureCollection;
 //! # #[cfg(feature = "geo-types")]
 //! use geo_types::{GeometryCollection, LineString, Polygon};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,9 @@
 //! a [`geo_types::GeometryCollection`](../geo_types/struct.GeometryCollection.html).
 //! See [here](#conversion-to-geo-objects) for details.
 //!
+//! Conversely, if you wish to produce a `FeatureCollection` from a collection of `geo` types, a `From` impl is
+//! provided for `&geo_types::GeometryCollection`.
+//!
 //! This crate uses `serde` for serialization.
 //! To get started, add `geojson` to your `Cargo.toml`:
 //!


### PR DESCRIPTION
While addressing #161, I once again had the feeling that this crate can be made of papercuts sometimes. Based on the assumption that one of the primary uses of GeoJSON as a format is the production of `FeatureCollection` objects, this PR provides some additional conversions from `Value` enum members and `Geometry` objects to `Feature` objects.
<s>I'm also considering an additional `From` impl to construct a `FeatureCollection` from a `geo_types::GeometryCollection`</s> Done!