### PR TITLE
Add FromIterator impl for FeatureCollection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## Unreleased
+
+* Added `FromIterator<Feature>` impl for `FeatureCollection`
+  * <https://github.com/georust/geojson/pull/171>
+
 ## 0.22.2
 
 * Added convenience methods to convert from geo_types::Geometry directly to GeoJson

--- a/src/feature_collection.rs
+++ b/src/feature_collection.rs
@@ -29,8 +29,6 @@ use crate::{util, Bbox, Feature};
 /// Serialization:
 ///
 /// ```
-/// # extern crate geojson;
-/// # fn main() {
 /// use geojson::FeatureCollection;
 /// use geojson::GeoJson;
 ///
@@ -46,14 +44,11 @@ use crate::{util, Bbox, Feature};
 ///     serialized,
 ///     "{\"features\":[],\"type\":\"FeatureCollection\"}"
 /// );
-/// # }
 /// ```
 ///
 /// Collect from an iterator:
 ///
 /// ```rust
-/// # extern crate geojson;
-/// # fn main() {
 /// use geojson::{FeatureCollection, Feature, Value};
 ///
 /// let fc: FeatureCollection = (0..10).map(|idx| -> Feature {
@@ -61,7 +56,6 @@ use crate::{util, Bbox, Feature};
 ///     Value::Point(vec![1.0 * c, 2.0 * c, 3.0 * c]).into()
 /// }).collect();
 /// assert_eq!(fc.features.len(), 10);
-/// # }
 /// ```
 #[derive(Clone, Debug, PartialEq)]
 pub struct FeatureCollection {
@@ -251,17 +245,6 @@ mod tests {
 
         let fc: FeatureCollection = features.into_iter().collect();
         assert_eq!(fc.features.len(), 2);
-
-        assert!(fc.bbox.is_some());
-        let bbox = fc.bbox.as_ref().unwrap();
-        assert_eq!(bbox.len(), 6);
-        for (i, coord) in bbox.iter().enumerate() {
-            if i < bbox.len() / 2 {
-                assert!(*coord <= -1.);
-            } else {
-                assert!(*coord >= 11.);
-            }
-        }
-
+        assert_eq!(fc.bbox, Some(vec![-1., -1., -1., 11., 11., 11.]));
     }
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

## Implementation Checklist

To summarize, this is the impl. checklist I'm suggesting:

1. [x] `FromIterator for FeatureCollection` 
2. [ ] ~~`From<&'a T> for Feature where From<&'a T> for Value`, T: BoundingRect~~
3. [x] Ensure correct bbox calculations in 1 ~~and 2 above~~


@michaelkirk @urschrei I realize we can't use `BoundingRect` as we only depend on `geo-types`.  Now, I'm a bit hesitant to add impl from geo-types -> `Feature` given it's just a conversion to `Value`, then to `Feature`.  The users could do this themselves by converting to `Value` then using `.into()` method. 

The PR currently just adds `FromIterator` impl.  Should add some tests for this;  have an examples collections with bbox to try out with?  We could also improve the docs for `Value`; currently it is hidden deep, and doesn't explain usage.