### PR TITLE
Add an example of converting from geojson to geo_types in the Geometr…

### DIFF
--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -223,6 +223,18 @@ impl Serialize for Value {
 ///     geometry,
 /// );
 /// ```
+///
+/// Transforming a `Geometry` into a `geo_types::Geometry<f64>` (which requires the `geo-types`
+/// feature):
+///
+/// ```
+/// use geojson::{Geometry, Value};
+/// use std::convert::TryInto;
+///
+/// let geometry = Geometry::new(Value::Point(vec![7.428959, 1.513394]));
+/// # #[cfg(feature = "geo-types")]
+/// let geom: geo_types::Geometry<f64> = geometry.try_into().unwrap();
+/// ```
 #[derive(Clone, Debug, PartialEq)]
 pub struct Geometry {
     /// Bounding Box


### PR DESCRIPTION
…y docs

- [X] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

I somehow managed to miss https://docs.rs/geojson/0.22.2/geojson/index.html#conversion-to-geo-objects. I think it could be helpful to repeat how to convert from `geojson` to `geo-types` here too. Skimming over methods in the docs is easy, but all the `TryInto` traits stuff is harder to spot.