### PR TITLE
Fix comment for consistency

### DIFF
--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -45,7 +45,7 @@ mod roundtrip_tests {
         test_null_geometry: "nullgeometry.geojson",
     }
 
-    /// Verifies that we can parse and then reencode geojson back to the same representation
+    /// Verifies that we can parse and then re-encode geojson back to the same representation
     /// without losing any data.
     fn test_round_trip(file_path: &str) {
         let mut file = File::open(&file_path).unwrap();


### PR DESCRIPTION
In the comment down below, "re-encode" is spelled the more popular way, with a dash, in the one above, it is not.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

