### PR TITLE
feature without 'properties' key doesn't error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## UNRELEASED
+
+* Allow parsing Feature/FeatureCollection that are missing a "properties" key.
+  * <https://github.com/georust/geojson/pull/182>
+
 ## 0.22.3
 
 * Added `FromIterator<Feature>` impl for `FeatureCollection`

--- a/src/geojson.rs
+++ b/src/geojson.rs
@@ -452,6 +452,31 @@ mod tests {
     }
 
     #[test]
+    fn test_missing_properties_key() {
+        let json_value = json!({
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [102.0, 0.5]
+            },
+        });
+
+        assert!(json_value.is_object());
+
+        let geojson: GeoJson = json_value.try_into().unwrap();
+        assert_eq!(
+            geojson,
+            GeoJson::Feature(Feature {
+                bbox: None,
+                geometry: Some(Geometry::new(Value::Point(vec![102.0, 0.5]))),
+                id: None,
+                properties: None,
+                foreign_members: None,
+            })
+        );
+    }
+
+    #[test]
     fn test_invalid_json() {
         let geojson_str = r#"{
            "type": "FeatureCollection",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,6 +389,10 @@ pub struct Feature {
     /// Properties
     ///
     /// [GeoJSON Format Specification § 3.2](https://tools.ietf.org/html/rfc7946#section-3.2)
+    ///
+    /// NOTE: This crate will permissively parse a Feature whose json is missing a `properties` key.
+    /// Because the spec implies that the `properties` key must be present, we will always include
+    /// the `properties` key when serializing.
     pub properties: Option<json::JsonObject>,
     /// Foreign Members
     ///

--- a/src/util.rs
+++ b/src/util.rs
@@ -103,11 +103,12 @@ pub fn get_foreign_members(object: JsonObject) -> Result<Option<JsonObject>, Err
 
 /// Used by Feature
 pub fn get_properties(object: &mut JsonObject) -> Result<Option<JsonObject>, Error> {
-    let properties = expect_property(object, "properties")?;
+    let properties = expect_property(object, "properties");
     match properties {
-        JsonValue::Object(x) => Ok(Some(x)),
-        JsonValue::Null => Ok(None),
-        _ => Err(Error::PropertiesExpectedObjectOrNull(properties)),
+        Ok(JsonValue::Object(x)) => Ok(Some(x)),
+        Ok(JsonValue::Null) | Err(Error::ExpectedProperty(_)) => Ok(None),
+        Ok(not_a_dictionary) => Err(Error::PropertiesExpectedObjectOrNull(not_a_dictionary)),
+        Err(e) => Err(e)
     }
 }
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

I think "properties" is actually a required field for Feature and FeatureCollections, but sometimes in the wild it's missing. 

In the interest of being strict about what we emit while being permissive about what we accept, I think it'd be helpful for users to go forward when there is no properties key, and treat it just like null or empty properties.

FWIW, ogr2ogr handles this without exploding.

