### PR TITLE
Revamp docs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 * Allow parsing Feature/FeatureCollection that are missing a "properties" key.
   * <https://github.com/georust/geojson/pull/182>
+* Overhauled front page documentation.
+  * <https://github.com/georust/geojson/pull/183>
 
 ## 0.22.3
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -108,7 +108,7 @@ pub fn get_properties(object: &mut JsonObject) -> Result<Option<JsonObject>, Err
         Ok(JsonValue::Object(x)) => Ok(Some(x)),
         Ok(JsonValue::Null) | Err(Error::ExpectedProperty(_)) => Ok(None),
         Ok(not_a_dictionary) => Err(Error::PropertiesExpectedObjectOrNull(not_a_dictionary)),
-        Err(e) => Err(e)
+        Err(e) => Err(e),
     }
 }
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Some of it I hope is uncontroversial:

- there were references to old serialization engines.
- linkified more entities

Some of it is potentially more controversial - and I'm open to changing
it based on feedback:

Primarily, I attempted to make the docs more perusable for people that
like to gloss over and find examples, while maintaining a decent amount
of coherent narrative for the blessed people that actually read docs top
to bottom.


