### PR TITLE
Parse inner GeoJson members directly from str

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@
   * <https://github.com/georust/geojson/pull/182>
 * Overhauled front page documentation.
   * <https://github.com/georust/geojson/pull/183>
+* Parse `Geometry`/`Feature`/`FeatureCollection` directly from str rather than
+  via `GeoJson` when you know what you're expecting.
+  * <https://github.com/georust/geojson/pull/188>
 * `Feature` now derives `Default`
   * <https://github.com/georust/geojson/pull/190>
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

A small ergonomics tweak:

Before:

    let gj = geojson::GeoJson::from_str(#r"{"type": "Geometry", "coordinates": [1, 2]}"#);
    let geom = geojson::Geometry::try_from(gj);

After:

    let geom = geojson::Geometry::from_str(#r"{"type": "Geometry", "coordinates": [1, 2]}"#);

