### PR TITLE
enable geo-types integration by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## UNRELEASED
+
+* Enable optional geo-types integration by default.
+  * <https://github.com/georust/geojson/pull/189>
+
 ## 0.22.4
 
 * Allow parsing `Feature`/`FeatureCollection` that are missing a `"properties"` key.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ documentation = "https://docs.rs/geojson/"
 keywords = ["geojson", "gis", "json", "geo"]
 edition = "2018"
 
+[features]
+default = ["geo-types"]
+
 [dependencies]
 serde = "~1.0"
 serde_json = "~1.0"


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Long standing request at #118.

Someone was in discord yesterday because of this and I tripped on it myself today. Anyone opposed?

