### PR TITLE
Reexport `JsonObject` and `JsonValue` from `serde_json`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## UNRELEASED
 
-* Allow parsing Feature/FeatureCollection that are missing a "properties" key.
+* Allow parsing `Feature`/`FeatureCollection` that are missing a `"properties"` key.
   * <https://github.com/georust/geojson/pull/182>
 * Overhauled front page documentation.
   * <https://github.com/georust/geojson/pull/183>
@@ -11,6 +11,8 @@
   * <https://github.com/georust/geojson/pull/188>
 * `Feature` now derives `Default`
   * <https://github.com/georust/geojson/pull/190>
+* Reexport `JsonObject` and `JsonValue` from `serde_json`.
+  * <https://github.com/georust/geojson/pull/191>
 
 ## 0.22.3
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-geojson
-=======
+# geojson
 
 [Documentation](https://docs.rs/geojson/)
 
@@ -35,8 +34,7 @@ let geojson = geojson_str.parse::<GeoJson>().unwrap();
 ### Writing
 
 ```rust
-use geojson::{Feature, GeoJson, Geometry, Value};
-use serde_json::{Map, to_value};
+use geojson::{Feature, GeoJson, Geometry, Value, JsonObject, JsonValue};
 
 let geometry = Geometry::new(
     Value::Point(vec![-120.66029,35.2812])
@@ -45,7 +43,7 @@ let geometry = Geometry::new(
 let mut properties = Map::new();
 properties.insert(
     String::from("name"),
-    to_value("Firestone Grill").unwrap(),
+    JsonValue::from("Firestone Grill"),
 );
 
 let geojson = GeoJson::Feature(Feature {
@@ -63,8 +61,8 @@ let geojson_string = geojson.to_string();
 
 Licensed under either of
 
- * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+* Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 at your option.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ let geometry = Geometry::new(
     Value::Point(vec![-120.66029,35.2812])
 );
 
-let mut properties = Map::new();
+let mut properties = JsonObject::new();
 properties.insert(
     String::from("name"),
     JsonValue::from("Firestone Grill"),

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -16,7 +16,9 @@ use std::convert::TryFrom;
 use std::str::FromStr;
 
 use crate::errors::Error;
-use crate::json::{json, Deserialize, Deserializer, JsonObject, JsonValue, Serialize, Serializer};
+use crate::{JsonObject, JsonValue};
+use serde_json::json;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use crate::{util, Feature, Geometry, Value};
 
 impl From<Geometry> for Feature {
@@ -220,7 +222,8 @@ impl Serialize for Id {
 
 #[cfg(test)]
 mod tests {
-    use crate::json::json;
+    use serde_json::json;
+    use crate::JsonObject;
     use crate::{feature, Error, Feature, GeoJson, Geometry, Value};
 
     use std::str::FromStr;
@@ -230,8 +233,8 @@ mod tests {
          \"Feature\"}"
     }
 
-    fn properties() -> Option<crate::json::JsonObject> {
-        Some(crate::json::JsonObject::new())
+    fn properties() -> Option<JsonObject> {
+        Some(JsonObject::new())
     }
 
     fn feature() -> Feature {
@@ -415,7 +418,7 @@ mod tests {
 
     #[test]
     fn encode_decode_feature_with_foreign_member() {
-        use crate::json::JsonObject;
+        use crate::JsonObject;
         use serde_json;
         let feature_json_str = "{\"geometry\":{\"coordinates\":[1.1,2.1],\"type\":\"Point\"},\"other_member\":\"some_value\",\"properties\":{},\"type\":\"Feature\"}";
         let mut foreign_members = JsonObject::new();

--- a/src/feature_collection.rs
+++ b/src/feature_collection.rs
@@ -17,7 +17,9 @@ use std::iter::FromIterator;
 use std::str::FromStr;
 
 use crate::errors::Error;
-use crate::json::{json, Deserialize, Deserializer, JsonObject, JsonValue, Serialize, Serializer};
+use crate::{JsonObject, JsonValue};
+use serde_json::json;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use crate::{util, Bbox, Feature};
 
 /// Feature Collection Objects
@@ -231,7 +233,7 @@ impl FromIterator<Feature> for FeatureCollection {
 
 #[cfg(test)]
 mod tests {
-    use crate::json::json;
+    use serde_json::json;
     use crate::{Error, Feature, FeatureCollection, Value};
 
     use std::str::FromStr;

--- a/src/geojson.rs
+++ b/src/geojson.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 use crate::errors::Error;
-use crate::json::{self, Deserialize, Deserializer, JsonObject, JsonValue, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use crate::{JsonObject, JsonValue};
 use crate::{Feature, FeatureCollection, Geometry};
 use std::convert::TryFrom;
 use std::fmt;
@@ -233,7 +234,7 @@ impl TryFrom<JsonObject> for GeoJson {
 
     fn try_from(object: JsonObject) -> Result<Self, Self::Error> {
         let type_ = match object.get("type") {
-            Some(json::JsonValue::String(t)) => Type::from_str(t),
+            Some(JsonValue::String(t)) => Type::from_str(t),
             _ => return Err(Error::GeometryUnknownType("type".to_owned())),
         };
         let type_ = type_.ok_or(Error::EmptyType)?;
@@ -350,9 +351,9 @@ impl FromStr for GeoJson {
     }
 }
 
-fn get_object(s: &str) -> Result<json::JsonObject, Error> {
+fn get_object(s: &str) -> Result<JsonObject, Error> {
     match ::serde_json::from_str(s) {
-        Ok(json::JsonValue::Object(object)) => Ok(object),
+        Ok(JsonValue::Object(object)) => Ok(object),
         Ok(other) => Err(Error::ExpectedObjectValue(other)),
         Err(serde_error) => Err(Error::MalformedJson(serde_error)),
     }

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -16,7 +16,8 @@ use std::str::FromStr;
 use std::{convert::TryFrom, fmt};
 
 use crate::errors::Error;
-use crate::json::{Deserialize, Deserializer, JsonObject, JsonValue, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use crate::{JsonObject, JsonValue};
 use crate::{util, Bbox, LineStringType, PointType, PolygonType};
 
 /// The underlying value for a `Geometry`.
@@ -343,9 +344,8 @@ where
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
-
-    use crate::json::{json, JsonObject};
-    use crate::{Error, GeoJson, Geometry, Value};
+    use serde_json::json;
+    use crate::{Error, GeoJson, Geometry, Value, JsonObject};
 
     fn encode(geometry: &Geometry) -> String {
         serde_json::to_string(&geometry).unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,11 +97,11 @@
 //!
 //! ```rust
 //! use geojson::{Feature, GeoJson, Geometry, Value};
-//! # fn get_properties() -> ::serde_json::Map<String, ::serde_json::Value> {
-//! # let mut properties = ::serde_json::Map::new();
+//! # fn get_properties() -> ::geojson::JsonObject {
+//! # let mut properties = ::geojson::JsonObject::new();
 //! # properties.insert(
 //! #     String::from("name"),
-//! #     ::serde_json::Value::String("Firestone Grill".to_string()),
+//! #     ::geojson::JsonValue::from("Firestone Grill"),
 //! # );
 //! # properties
 //! # }
@@ -129,12 +129,11 @@
 //! values](../serde_json/value/index.html).
 //!
 //! ```
-//! use serde_json;
+//! use geojson::{JsonObject, JsonValue};
 //!
-//! let mut properties = serde_json::Map::new();
+//! let mut properties = JsonObject::new();
 //! let key = "name".to_string();
-//! let value = "Firestone Grill".to_string();
-//! properties.insert(key, serde_json::to_value(value).unwrap());
+//! properties.insert(key, JsonValue::from("Firestone Grill"));
 //! ```
 //!
 //! ## Parsing
@@ -447,15 +446,12 @@ pub struct Feature {
     /// NOTE: This crate will permissively parse a Feature whose json is missing a `properties` key.
     /// Because the spec implies that the `properties` key must be present, we will always include
     /// the `properties` key when serializing.
-    pub properties: Option<json::JsonObject>,
+    pub properties: Option<JsonObject>,
     /// Foreign Members
     ///
     /// [GeoJSON Format Specification § 6](https://tools.ietf.org/html/rfc7946#section-6)
-    pub foreign_members: Option<json::JsonObject>,
+    pub foreign_members: Option<JsonObject>,
 }
 
-mod json {
-    pub use serde::{Deserialize, Deserializer, Serialize, Serializer};
-    pub use serde_json::{json, Map, Value as JsonValue};
-    pub type JsonObject = Map<String, JsonValue>;
-}
+pub type JsonValue = serde_json::Value;
+pub type JsonObject = serde_json::Map<String, JsonValue>;

--- a/src/util.rs
+++ b/src/util.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::errors::Error;
-use crate::json::{JsonObject, JsonValue};
+use crate::{JsonObject, JsonValue};
 use crate::{feature, Bbox, Feature, Geometry, Position, Value};
 
 pub fn expect_type(value: &mut JsonObject) -> Result<String, Error> {


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Prior to this commit, users would need to add `serde_json` as a
dependency in order to construct a `Feature` with properties.

Fixes https://github.com/georust/geojson/issues/185

Before:

```rust
use geojson::{Feature, GeoJson, Geometry, Value};
use serde_json::{Map, to_value};

let geometry = Geometry::new(
    Value::Point(vec![-120.66029,35.2812])
);

let mut properties = Map::new();
properties.insert(
    String::from("name"),
    to_value("Firestone Grill").unwrap(),
);

let geojson = GeoJson::Feature(Feature {
    bbox: None,
    geometry: Some(geometry),
    id: None,
    properties: Some(properties),
    foreign_members: None,
});
```

After:

```rust
use geojson::{Feature, GeoJson, Geometry, Value, JsonObject, JsonValue};

let geometry = Geometry::new(
    Value::Point(vec![-120.66029,35.2812])
);

let mut properties = JsonObject::new();
properties.insert(
    String::from("name"),
    JsonValue::from("Firestone Grill"),
);

let geojson = GeoJson::Feature(Feature {
    bbox: None,
    geometry: Some(geometry),
    id: None,
    properties: Some(properties),
    foreign_members: None,
});
```