### PR TITLE
Fix converting a GeometryCollection Feature to geo_types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 * Enable optional geo-types integration by default.
   * <https://github.com/georust/geojson/pull/189>
+* FIX: converting a single GeometryCollection Feature to geo_types
+  * <https://github.com/georust/geojson/pull/194>
 
 ## 0.22.4
 

--- a/src/conversion/mod.rs
+++ b/src/conversion/mod.rs
@@ -118,13 +118,11 @@ where
         Value::MultiPolygon(_) => {
             Ok(TryInto::<GtMultiPolygon<_>>::try_into(geometry.value.clone())?.into())
         }
-        Value::GeometryCollection(gc) => {
-            let gc = GtGeometry::GeometryCollection(GeometryCollection(
-                gc.iter()
-                    .map(|geom| process_geometry(&geom))
-                    .collect::<Result<Vec<geo_types::Geometry<T>>, GJError>>()?,
-            ));
-            Ok(gc)
+        Value::GeometryCollection(_) => {
+            use std::convert::TryFrom;
+            Ok(GtGeometry::GeometryCollection(
+                GeometryCollection::try_from(geometry.value.clone())?,
+            ))
         }
     }
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

FIXES #193 

We were correctly handling this conversion in `process_geom` which is used by the `quick_collection` code path for `FeatureCollection`s, but similar logic was missing from the `TryFrom` code path.

To fix the issue - I consolidated the `process_geom` method into the `TryFrom` impl, which allowed for deleting some now redundant code.