### PR TITLE
Add `geojson::Result<T>` and apply it to codebase

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 * Added IntoIter implementation for FeatureCollection.
   * <https://github.com/georust/geojson/pull/196>
+* Add `geojson::Result<T>`
+  * <https://github.com/georust/geojson/pull/198>
 
 ## 0.23.0
 

--- a/src/conversion/mod.rs
+++ b/src/conversion/mod.rs
@@ -17,7 +17,7 @@ use crate::geo_types::{self, CoordFloat, GeometryCollection};
 use crate::geojson::GeoJson;
 use crate::geojson::GeoJson::{Feature, FeatureCollection, Geometry};
 
-use crate::Error as GJError;
+use crate::Result;
 use std::convert::TryInto;
 
 #[cfg(test)]
@@ -67,7 +67,7 @@ pub(crate) mod from_geo_types;
 pub(crate) mod to_geo_types;
 
 // Process top-level `GeoJSON` items, returning a geo_types::GeometryCollection or an Error
-fn process_geojson<T>(gj: &GeoJson) -> Result<geo_types::GeometryCollection<T>, GJError>
+fn process_geojson<T>(gj: &GeoJson) -> Result<geo_types::GeometryCollection<T>>
 where
     T: CoordFloat,
 {
@@ -79,7 +79,7 @@ where
                 // Only pass on non-empty geometries
                 .filter_map(|feature| feature.geometry.as_ref())
                 .map(|geometry| geometry.clone().try_into())
-                .collect::<Result<_, _>>()?,
+                .collect::<Result<_>>()?,
         )),
         Feature(feature) => {
             if let Some(geometry) = &feature.geometry {
@@ -126,7 +126,7 @@ where
 /// let mut collection: GeometryCollection<f64> = quick_collection(&geojson).unwrap();
 /// ```
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
-pub fn quick_collection<T>(gj: &GeoJson) -> Result<geo_types::GeometryCollection<T>, GJError>
+pub fn quick_collection<T>(gj: &GeoJson) -> Result<geo_types::GeometryCollection<T>>
 where
     T: CoordFloat,
 {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -28,7 +28,7 @@ pub enum Error {
     #[error("Encountered an unknown 'geometry' object type: `{0}`")]
     GeometryUnknownType(String),
     #[error("Encountered malformed JSON: {0}")]
-    MalformedJson(serde_json::error::Error),
+    MalformedJson(serde_json::Error),
     #[error("Encountered neither object type nor null type for 'properties' object: `{0}`")]
     PropertiesExpectedObjectOrNull(Value),
     #[error("Encountered neither object type nor null type for 'geometry' field on 'feature' object: `{0}`")]
@@ -49,4 +49,12 @@ pub enum Error {
     ExpectedArrayValue(String),
     #[error("Expected an owned Object, but got `{0}`")]
     ExpectedObjectValue(Value),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+impl From<serde_json::Error> for Error {
+    fn from(error: serde_json::Error) -> Self {
+        Self::MalformedJson(error)
+    }
 }

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -15,7 +15,7 @@
 use std::convert::TryFrom;
 use std::str::FromStr;
 
-use crate::errors::Error;
+use crate::errors::{Error, Result};
 use crate::{util, Feature, Geometry, Value};
 use crate::{JsonObject, JsonValue};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -48,7 +48,7 @@ impl From<Value> for Feature {
 impl FromStr for Feature {
     type Err = Error;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> Result<Self> {
         Self::try_from(crate::GeoJson::from_str(s)?)
     }
 }
@@ -88,11 +88,11 @@ impl<'a> From<&'a Feature> for JsonObject {
 }
 
 impl Feature {
-    pub fn from_json_object(object: JsonObject) -> Result<Self, Error> {
+    pub fn from_json_object(object: JsonObject) -> Result<Self> {
         Self::try_from(object)
     }
 
-    pub fn from_json_value(value: JsonValue) -> Result<Self, Error> {
+    pub fn from_json_value(value: JsonValue) -> Result<Self> {
         Self::try_from(value)
     }
 
@@ -150,7 +150,7 @@ impl Feature {
 impl TryFrom<JsonObject> for Feature {
     type Error = Error;
 
-    fn try_from(mut object: JsonObject) -> Result<Self, Error> {
+    fn try_from(mut object: JsonObject) -> Result<Self> {
         let res = &*util::expect_type(&mut object)?;
         match res {
             "Feature" => Ok(Feature {
@@ -168,7 +168,7 @@ impl TryFrom<JsonObject> for Feature {
 impl TryFrom<JsonValue> for Feature {
     type Error = Error;
 
-    fn try_from(value: JsonValue) -> Result<Self, Self::Error> {
+    fn try_from(value: JsonValue) -> Result<Self> {
         if let JsonValue::Object(obj) = value {
             Self::try_from(obj)
         } else {
@@ -178,7 +178,7 @@ impl TryFrom<JsonValue> for Feature {
 }
 
 impl Serialize for Feature {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
@@ -187,7 +187,7 @@ impl Serialize for Feature {
 }
 
 impl<'de> Deserialize<'de> for Feature {
-    fn deserialize<D>(deserializer: D) -> Result<Feature, D::Error>
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Feature, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -209,7 +209,7 @@ pub enum Id {
 }
 
 impl Serialize for Id {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: Serializer,
     {

--- a/src/feature_collection.rs
+++ b/src/feature_collection.rs
@@ -16,7 +16,7 @@ use std::convert::TryFrom;
 use std::iter::FromIterator;
 use std::str::FromStr;
 
-use crate::errors::Error;
+use crate::errors::{Error, Result};
 use crate::{util, Bbox, Feature};
 use crate::{JsonObject, JsonValue};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -116,11 +116,11 @@ impl<'a> From<&'a FeatureCollection> for JsonObject {
 }
 
 impl FeatureCollection {
-    pub fn from_json_object(object: JsonObject) -> Result<Self, Error> {
+    pub fn from_json_object(object: JsonObject) -> Result<Self> {
         Self::try_from(object)
     }
 
-    pub fn from_json_value(value: JsonValue) -> Result<Self, Error> {
+    pub fn from_json_value(value: JsonValue) -> Result<Self> {
         Self::try_from(value)
     }
 }
@@ -128,7 +128,7 @@ impl FeatureCollection {
 impl TryFrom<JsonObject> for FeatureCollection {
     type Error = Error;
 
-    fn try_from(mut object: JsonObject) -> Result<Self, Error> {
+    fn try_from(mut object: JsonObject) -> Result<Self> {
         match util::expect_type(&mut object)? {
             ref type_ if type_ == "FeatureCollection" => Ok(FeatureCollection {
                 bbox: util::get_bbox(&mut object)?,
@@ -146,7 +146,7 @@ impl TryFrom<JsonObject> for FeatureCollection {
 impl TryFrom<JsonValue> for FeatureCollection {
     type Error = Error;
 
-    fn try_from(value: JsonValue) -> Result<Self, Error> {
+    fn try_from(value: JsonValue) -> Result<Self> {
         if let JsonValue::Object(obj) = value {
             Self::try_from(obj)
         } else {
@@ -158,13 +158,13 @@ impl TryFrom<JsonValue> for FeatureCollection {
 impl FromStr for FeatureCollection {
     type Err = Error;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> Result<Self> {
         Self::try_from(crate::GeoJson::from_str(s)?)
     }
 }
 
 impl Serialize for FeatureCollection {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
@@ -173,7 +173,7 @@ impl Serialize for FeatureCollection {
 }
 
 impl<'de> Deserialize<'de> for FeatureCollection {
-    fn deserialize<D>(deserializer: D) -> Result<FeatureCollection, D::Error>
+    fn deserialize<D>(deserializer: D) -> std::result::Result<FeatureCollection, D::Error>
     where
         D: Deserializer<'de>,
     {

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -15,7 +15,7 @@
 use std::str::FromStr;
 use std::{convert::TryFrom, fmt};
 
-use crate::errors::Error;
+use crate::errors::{Error, Result};
 use crate::{util, Bbox, LineStringType, PointType, PolygonType};
 use crate::{JsonObject, JsonValue};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -110,11 +110,11 @@ impl<'a> From<&'a Value> for JsonObject {
 }
 
 impl Value {
-    pub fn from_json_object(object: JsonObject) -> Result<Self, Error> {
+    pub fn from_json_object(object: JsonObject) -> Result<Self> {
         Self::try_from(object)
     }
 
-    pub fn from_json_value(value: JsonValue) -> Result<Self, Error> {
+    pub fn from_json_value(value: JsonValue) -> Result<Self> {
         Self::try_from(value)
     }
 }
@@ -122,7 +122,7 @@ impl Value {
 impl TryFrom<JsonObject> for Value {
     type Error = Error;
 
-    fn try_from(mut object: JsonObject) -> Result<Self, Self::Error> {
+    fn try_from(mut object: JsonObject) -> Result<Self> {
         util::get_value(&mut object)
     }
 }
@@ -130,7 +130,7 @@ impl TryFrom<JsonObject> for Value {
 impl TryFrom<JsonValue> for Value {
     type Error = Error;
 
-    fn try_from(value: JsonValue) -> Result<Self, Self::Error> {
+    fn try_from(value: JsonValue) -> Result<Self> {
         if let JsonValue::Object(obj) = value {
             Self::try_from(obj)
         } else {
@@ -163,7 +163,7 @@ impl<'a> From<&'a Value> for JsonValue {
 }
 
 impl Serialize for Value {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
@@ -278,11 +278,11 @@ impl<'a> From<&'a Geometry> for JsonObject {
 }
 
 impl Geometry {
-    pub fn from_json_object(object: JsonObject) -> Result<Self, Error> {
+    pub fn from_json_object(object: JsonObject) -> Result<Self> {
         Self::try_from(object)
     }
 
-    pub fn from_json_value(value: JsonValue) -> Result<Self, Error> {
+    pub fn from_json_value(value: JsonValue) -> Result<Self> {
         Self::try_from(value)
     }
 }
@@ -290,7 +290,7 @@ impl Geometry {
 impl TryFrom<JsonObject> for Geometry {
     type Error = Error;
 
-    fn try_from(mut object: JsonObject) -> Result<Self, Self::Error> {
+    fn try_from(mut object: JsonObject) -> Result<Self> {
         let bbox = util::get_bbox(&mut object)?;
         let value = util::get_value(&mut object)?;
         let foreign_members = util::get_foreign_members(object)?;
@@ -305,7 +305,7 @@ impl TryFrom<JsonObject> for Geometry {
 impl TryFrom<JsonValue> for Geometry {
     type Error = Error;
 
-    fn try_from(value: JsonValue) -> Result<Self, Self::Error> {
+    fn try_from(value: JsonValue) -> Result<Self> {
         if let JsonValue::Object(obj) = value {
             Self::try_from(obj)
         } else {
@@ -317,13 +317,13 @@ impl TryFrom<JsonValue> for Geometry {
 impl FromStr for Geometry {
     type Err = Error;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> Result<Self> {
         Self::try_from(crate::GeoJson::from_str(s)?)
     }
 }
 
 impl Serialize for Geometry {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
@@ -332,7 +332,7 @@ impl Serialize for Geometry {
 }
 
 impl<'de> Deserialize<'de> for Geometry {
-    fn deserialize<D>(deserializer: D) -> Result<Geometry, D::Error>
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Geometry, D::Error>
     where
         D: Deserializer<'de>,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -414,7 +414,7 @@ mod feature_iterator;
 pub use crate::feature_iterator::FeatureIterator;
 
 pub mod errors;
-pub use crate::errors::Error;
+pub use crate::errors::{Error, Result};
 
 #[cfg(feature = "geo-types")]
 mod conversion;

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,44 +12,44 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::errors::Error;
+use crate::errors::{Error, Result};
 use crate::{feature, Bbox, Feature, Geometry, Position, Value};
 use crate::{JsonObject, JsonValue};
 
-pub fn expect_type(value: &mut JsonObject) -> Result<String, Error> {
+pub fn expect_type(value: &mut JsonObject) -> Result<String> {
     let prop = expect_property(value, "type")?;
     expect_string(prop)
 }
 
-pub fn expect_string(value: JsonValue) -> Result<String, Error> {
+pub fn expect_string(value: JsonValue) -> Result<String> {
     match value {
         JsonValue::String(s) => Ok(s),
         _ => Err(Error::ExpectedStringValue(value)),
     }
 }
 
-pub fn expect_f64(value: &JsonValue) -> Result<f64, Error> {
+pub fn expect_f64(value: &JsonValue) -> Result<f64> {
     match value.as_f64() {
         Some(v) => Ok(v),
         None => Err(Error::ExpectedF64Value),
     }
 }
 
-pub fn expect_array(value: &JsonValue) -> Result<&Vec<JsonValue>, Error> {
+pub fn expect_array(value: &JsonValue) -> Result<&Vec<JsonValue>> {
     match value.as_array() {
         Some(v) => Ok(v),
         None => Err(Error::ExpectedArrayValue("None".to_string())),
     }
 }
 
-fn expect_property(obj: &mut JsonObject, name: &'static str) -> Result<JsonValue, Error> {
+fn expect_property(obj: &mut JsonObject, name: &'static str) -> Result<JsonValue> {
     match obj.remove(name) {
         Some(v) => Ok(v),
         None => Err(Error::ExpectedProperty(name.to_string())),
     }
 }
 
-fn expect_owned_array(value: JsonValue) -> Result<Vec<JsonValue>, Error> {
+fn expect_owned_array(value: JsonValue) -> Result<Vec<JsonValue>> {
     match value {
         JsonValue::Array(v) => Ok(v),
         _ => match value {
@@ -64,19 +64,19 @@ fn expect_owned_array(value: JsonValue) -> Result<Vec<JsonValue>, Error> {
     }
 }
 
-fn expect_owned_object(value: JsonValue) -> Result<JsonObject, Error> {
+fn expect_owned_object(value: JsonValue) -> Result<JsonObject> {
     match value {
         JsonValue::Object(o) => Ok(o),
         _ => Err(Error::ExpectedObjectValue(value)),
     }
 }
 
-pub fn get_coords_value(object: &mut JsonObject) -> Result<JsonValue, Error> {
+pub fn get_coords_value(object: &mut JsonObject) -> Result<JsonValue> {
     expect_property(object, "coordinates")
 }
 
 /// Used by FeatureCollection, Feature, Geometry
-pub fn get_bbox(object: &mut JsonObject) -> Result<Option<Bbox>, Error> {
+pub fn get_bbox(object: &mut JsonObject) -> Result<Option<Bbox>> {
     let bbox_json = match object.remove("bbox") {
         Some(b) => b,
         None => return Ok(None),
@@ -88,12 +88,12 @@ pub fn get_bbox(object: &mut JsonObject) -> Result<Option<Bbox>, Error> {
     let bbox = bbox_array
         .into_iter()
         .map(|i| i.as_f64().ok_or(Error::BboxExpectedNumericValues(i)))
-        .collect::<Result<Vec<_>, _>>()?;
+        .collect::<Result<Vec<_>>>()?;
     Ok(Some(bbox))
 }
 
 /// Used by FeatureCollection, Feature, Geometry
-pub fn get_foreign_members(object: JsonObject) -> Result<Option<JsonObject>, Error> {
+pub fn get_foreign_members(object: JsonObject) -> Result<Option<JsonObject>> {
     if object.is_empty() {
         Ok(None)
     } else {
@@ -102,7 +102,7 @@ pub fn get_foreign_members(object: JsonObject) -> Result<Option<JsonObject>, Err
 }
 
 /// Used by Feature
-pub fn get_properties(object: &mut JsonObject) -> Result<Option<JsonObject>, Error> {
+pub fn get_properties(object: &mut JsonObject) -> Result<Option<JsonObject>> {
     let properties = expect_property(object, "properties");
     match properties {
         Ok(JsonValue::Object(x)) => Ok(Some(x)),
@@ -115,7 +115,7 @@ pub fn get_properties(object: &mut JsonObject) -> Result<Option<JsonObject>, Err
 /// Retrieve a single Position from the value of the "coordinates" key
 ///
 /// Used by Value::Point
-pub fn get_coords_one_pos(object: &mut JsonObject) -> Result<Position, Error> {
+pub fn get_coords_one_pos(object: &mut JsonObject) -> Result<Position> {
     let coords_json = get_coords_value(object)?;
     json_to_position(&coords_json)
 }
@@ -123,7 +123,7 @@ pub fn get_coords_one_pos(object: &mut JsonObject) -> Result<Position, Error> {
 /// Retrieve a one dimensional Vec of Positions from the value of the "coordinates" key
 ///
 /// Used by Value::MultiPoint and Value::LineString
-pub fn get_coords_1d_pos(object: &mut JsonObject) -> Result<Vec<Position>, Error> {
+pub fn get_coords_1d_pos(object: &mut JsonObject) -> Result<Vec<Position>> {
     let coords_json = get_coords_value(object)?;
     json_to_1d_positions(&coords_json)
 }
@@ -131,7 +131,7 @@ pub fn get_coords_1d_pos(object: &mut JsonObject) -> Result<Vec<Position>, Error
 /// Retrieve a two dimensional Vec of Positions from the value of the "coordinates" key
 ///
 /// Used by Value::MultiLineString and Value::Polygon
-pub fn get_coords_2d_pos(object: &mut JsonObject) -> Result<Vec<Vec<Position>>, Error> {
+pub fn get_coords_2d_pos(object: &mut JsonObject) -> Result<Vec<Vec<Position>>> {
     let coords_json = get_coords_value(object)?;
     json_to_2d_positions(&coords_json)
 }
@@ -139,13 +139,13 @@ pub fn get_coords_2d_pos(object: &mut JsonObject) -> Result<Vec<Vec<Position>>, 
 /// Retrieve a three dimensional Vec of Positions from the value of the "coordinates" key
 ///
 /// Used by Value::MultiPolygon
-pub fn get_coords_3d_pos(object: &mut JsonObject) -> Result<Vec<Vec<Vec<Position>>>, Error> {
+pub fn get_coords_3d_pos(object: &mut JsonObject) -> Result<Vec<Vec<Vec<Position>>>> {
     let coords_json = get_coords_value(object)?;
     json_to_3d_positions(&coords_json)
 }
 
 /// Used by Value::GeometryCollection
-pub fn get_geometries(object: &mut JsonObject) -> Result<Vec<Geometry>, Error> {
+pub fn get_geometries(object: &mut JsonObject) -> Result<Vec<Geometry>> {
     let geometries_json = expect_property(object, "geometries")?;
     let geometries_array = expect_owned_array(geometries_json)?;
     let mut geometries = Vec::with_capacity(geometries_array.len());
@@ -158,7 +158,7 @@ pub fn get_geometries(object: &mut JsonObject) -> Result<Vec<Geometry>, Error> {
 }
 
 /// Used by Feature
-pub fn get_id(object: &mut JsonObject) -> Result<Option<feature::Id>, Error> {
+pub fn get_id(object: &mut JsonObject) -> Result<Option<feature::Id>> {
     match object.remove("id") {
         Some(JsonValue::Number(x)) => Ok(Some(feature::Id::Number(x))),
         Some(JsonValue::String(s)) => Ok(Some(feature::Id::String(s))),
@@ -168,7 +168,7 @@ pub fn get_id(object: &mut JsonObject) -> Result<Option<feature::Id>, Error> {
 }
 
 /// Used by Geometry, Value
-pub fn get_value(object: &mut JsonObject) -> Result<Value, Error> {
+pub fn get_value(object: &mut JsonObject) -> Result<Value> {
     let res = &*expect_type(object)?;
     match res {
         "Point" => Ok(Value::Point(get_coords_one_pos(object)?)),
@@ -183,7 +183,7 @@ pub fn get_value(object: &mut JsonObject) -> Result<Value, Error> {
 }
 
 /// Used by Feature
-pub fn get_geometry(object: &mut JsonObject) -> Result<Option<Geometry>, Error> {
+pub fn get_geometry(object: &mut JsonObject) -> Result<Option<Geometry>> {
     let geometry = expect_property(object, "geometry")?;
     match geometry {
         JsonValue::Object(x) => {
@@ -196,7 +196,7 @@ pub fn get_geometry(object: &mut JsonObject) -> Result<Option<Geometry>, Error> 
 }
 
 /// Used by FeatureCollection
-pub fn get_features(object: &mut JsonObject) -> Result<Vec<Feature>, Error> {
+pub fn get_features(object: &mut JsonObject) -> Result<Vec<Feature>> {
     let prop = expect_property(object, "features")?;
     let features_json = expect_owned_array(prop)?;
     let mut features = Vec::with_capacity(features_json.len());
@@ -208,7 +208,7 @@ pub fn get_features(object: &mut JsonObject) -> Result<Vec<Feature>, Error> {
     Ok(features)
 }
 
-fn json_to_position(json: &JsonValue) -> Result<Position, Error> {
+fn json_to_position(json: &JsonValue) -> Result<Position> {
     let coords_array = expect_array(json)?;
     let mut coords = Vec::with_capacity(coords_array.len());
     for position in coords_array {
@@ -217,7 +217,7 @@ fn json_to_position(json: &JsonValue) -> Result<Position, Error> {
     Ok(coords)
 }
 
-fn json_to_1d_positions(json: &JsonValue) -> Result<Vec<Position>, Error> {
+fn json_to_1d_positions(json: &JsonValue) -> Result<Vec<Position>> {
     let coords_array = expect_array(json)?;
     let mut coords = Vec::with_capacity(coords_array.len());
     for item in coords_array {
@@ -226,7 +226,7 @@ fn json_to_1d_positions(json: &JsonValue) -> Result<Vec<Position>, Error> {
     Ok(coords)
 }
 
-fn json_to_2d_positions(json: &JsonValue) -> Result<Vec<Vec<Position>>, Error> {
+fn json_to_2d_positions(json: &JsonValue) -> Result<Vec<Vec<Position>>> {
     let coords_array = expect_array(json)?;
     let mut coords = Vec::with_capacity(coords_array.len());
     for item in coords_array {
@@ -235,7 +235,7 @@ fn json_to_2d_positions(json: &JsonValue) -> Result<Vec<Vec<Position>>, Error> {
     Ok(coords)
 }
 
-fn json_to_3d_positions(json: &JsonValue) -> Result<Vec<Vec<Vec<Position>>>, Error> {
+fn json_to_3d_positions(json: &JsonValue) -> Result<Vec<Vec<Vec<Position>>>> {
     let coords_array = expect_array(json)?;
     let mut coords = Vec::with_capacity(coords_array.len());
     for item in coords_array {


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This is a pretty superficial change, but I think it's nice. 

