### PR TITLE
GeoJSON to/from custom struct using serde

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,18 +15,17 @@
         name: String,
         age: u64,
     }
-    
+
     // read your input
     let my_structs: Vec<MyStruct> = geojson::de::deserialize_feature_collection(geojson_reader).unwrap();
-    
+
     // do some processing
     process(&mut my_structs);
-   
-    // write back your results 
+
+    // write back your results
     geojson::ser::to_feature_collection_string(&my_structs).unwrap();
     ```
   * PR: <https://github.com/georust/geojson/pull/199>
-
 * Added IntoIter implementation for FeatureCollection.
   * <https://github.com/georust/geojson/pull/196>
 * Added `geojson::Result<T>`.
@@ -34,6 +33,7 @@
 * BREAKING: Change the Result type of FeatureIterator from io::Result to crate::Result
   * <https://github.com/georust/geojson/pull/199>
 * Add `TryFrom<&geometry::Value>` for geo_type variants.
+  * <https://github.com/georust/geojson/pull/202>
 
 ## 0.23.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,12 +4,36 @@
 
 * Fix: FeatureIterator errors when reading "features" field before "type" field.
   * <https://github.com/georust/geojson/pull/200>
+* Added `geojson::{ser, de}` helpers to convert your custom struct to and from GeoJSON. 
+  * For external geometry types like geo-types, use the `serialize_geometry`/`deserialize_geometry` helpers.
+  * Example:
+    ```
+    #[derive(Serialize, Deserialize)]
+    struct MyStruct {
+        #[serde(serialize_with = "serialize_geometry", deserialize_with = "deserialize_geometry")]
+        geometry: geo_types::Point<f64>,
+        name: String,
+        age: u64,
+    }
+    
+    // read your input
+    let my_structs: Vec<MyStruct> = geojson::de::deserialize_feature_collection(geojson_reader).unwrap();
+    
+    // do some processing
+    process(&mut my_structs);
+   
+    // write back your results 
+    geojson::ser::to_feature_collection_string(&my_structs).unwrap();
+    ```
+  * PR: <https://github.com/georust/geojson/pull/199>
+
 * Added IntoIter implementation for FeatureCollection.
   * <https://github.com/georust/geojson/pull/196>
-* Add `geojson::Result<T>`
+* Added `geojson::Result<T>`.
   * <https://github.com/georust/geojson/pull/198>
+* BREAKING: Change the Result type of FeatureIterator from io::Result to crate::Result
+  * <https://github.com/georust/geojson/pull/199>
 * Add `TryFrom<&geometry::Value>` for geo_type variants.
-  * <https://github.com/georust/geojson/pull/202> 
 
 ## 0.23.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ edition = "2018"
 default = ["geo-types"]
 
 [dependencies]
-serde = "~1.0"
+serde = { version="~1.0", features = ["derive"] }
 serde_json = "~1.0"
-serde_derive = "~1.0"
-geo-types = { version = "0.7", optional = true }
+geo-types = { version = "0.7", features = ["serde"], optional = true }
 thiserror = "1.0.20"
+log = "0.4.17"
 
 [dev-dependencies]
 num-traits = "0.2"
@@ -26,6 +26,10 @@ criterion = "0.3"
 
 [[bench]]
 name = "parse"
+harness = false
+
+[[bench]]
+name = "serialize"
 harness = false
 
 [[bench]]

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -1,5 +1,8 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use geojson::de::deserialize_geometry;
 use geojson::GeoJson;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
 use std::io::BufReader;
 
 fn parse_feature_collection_benchmark(c: &mut Criterion) {
@@ -54,6 +57,33 @@ fn parse_feature_collection_benchmark(c: &mut Criterion) {
             });
         });
     });
+
+    #[cfg(feature="geo-types")]
+    c.bench_function(
+        "FeatureReader::deserialize to geo-types (countries.geojson)",
+        |b| {
+            b.iter(|| {
+                #[allow(unused)]
+                #[derive(serde::Deserialize)]
+                struct Country {
+                    #[serde(deserialize_with = "deserialize_geometry")]
+                    geometry: geo_types::Geometry,
+                    name: String,
+                }
+                let feature_reader =
+                    geojson::FeatureReader::from_reader(BufReader::new(geojson_str.as_bytes()));
+
+                let _ = black_box({
+                    let mut count = 0;
+                    for feature in feature_reader.deserialize::<Country>().unwrap() {
+                        let _ = feature.unwrap();
+                        count += 1;
+                    }
+                    assert_eq!(count, 180);
+                });
+            });
+        },
+    );
 }
 
 fn parse_geometry_collection_benchmark(c: &mut Criterion) {

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -18,21 +18,6 @@ fn parse_feature_collection_benchmark(c: &mut Criterion) {
         })
     });
 
-    c.bench_function("FeatureIter (countries.geojson)", |b| {
-        b.iter(|| {
-            let feature_iter =
-                geojson::FeatureIterator::new(BufReader::new(geojson_str.as_bytes()));
-            let _ = black_box({
-                let mut count = 0;
-                for feature in feature_iter {
-                    let _ = feature.unwrap();
-                    count += 1;
-                }
-                assert_eq!(count, 180);
-            });
-        });
-    });
-
     c.bench_function("FeatureReader::features (countries.geojson)", |b| {
         b.iter(|| {
             let feature_reader =
@@ -50,6 +35,7 @@ fn parse_feature_collection_benchmark(c: &mut Criterion) {
 
     c.bench_function("FeatureReader::deserialize (countries.geojson)", |b| {
         b.iter(|| {
+            #[allow(unused)]
             #[derive(serde::Deserialize)]
             struct Country {
                 geometry: geojson::Geometry,

--- a/benches/serialize.rs
+++ b/benches/serialize.rs
@@ -1,0 +1,45 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn serialize_feature_collection_benchmark(c: &mut Criterion) {
+    let geojson_str = include_str!("../tests/fixtures/countries.geojson");
+
+    c.bench_function(
+        "serialize geojson::FeatureCollection struct (countries.geojson)",
+        |b| {
+            let geojson = geojson_str.parse::<geojson::GeoJson>().unwrap();
+
+            b.iter(|| {
+                black_box({
+                    let geojson_string = serde_json::to_string(&geojson).unwrap();
+                    // Sanity check that we serialized a long string of some kind.
+                    assert_eq!(geojson_string.len(), 256890);
+                });
+            });
+        },
+    );
+
+    c.bench_function("serialize custom struct (countries.geojson)", |b| {
+        #[derive(serde::Serialize, serde::Deserialize)]
+        struct Country {
+            geometry: geojson::Geometry,
+            name: String,
+        }
+        let features =
+            geojson::de::deserialize_feature_collection_str_to_vec::<Country>(geojson_str).unwrap();
+        assert_eq!(features.len(), 180);
+
+        b.iter(|| {
+            black_box({
+                let geojson_string = geojson::ser::to_feature_collection_string(&features).unwrap();
+                // Sanity check that we serialized a long string of some kind.
+                //
+                // Note this is slightly shorter than the GeoJson round-trip above because we drop
+                // some fields, like foreign members
+                assert_eq!(geojson_string.len(), 254908);
+            });
+        });
+    });
+}
+
+criterion_group!(benches, serialize_feature_collection_benchmark);
+criterion_main!(benches);

--- a/benches/to_geo_types.rs
+++ b/benches/to_geo_types.rs
@@ -4,6 +4,7 @@ fn benchmark_group(c: &mut Criterion) {
     let geojson_str = include_str!("../tests/fixtures/countries.geojson");
     let geojson = geojson_str.parse::<geojson::GeoJson>().unwrap();
 
+    #[cfg(feature="geo-types")]
     c.bench_function("quick_collection", move |b| {
         b.iter(|| {
             let _: Result<geo_types::GeometryCollection<f64>, _> =

--- a/examples/deserialize.rs
+++ b/examples/deserialize.rs
@@ -1,0 +1,28 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+struct Country {
+    // see the geo_types example if you want to store
+    // geotypes in your struct
+    geometry: geojson::Geometry,
+    name: String,
+}
+
+use std::error::Error;
+use std::fs::File;
+use std::io::{BufReader, BufWriter};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let file_reader = BufReader::new(File::open("tests/fixtures/countries.geojson")?);
+
+    // Create a Vec of Country structs from the GeoJSON
+    let countries: Vec<Country> =
+        geojson::de::deserialize_feature_collection_to_vec::<Country>(file_reader)?;
+    assert_eq!(countries.len(), 180);
+
+    // Write the structs back to GeoJSON
+    let file_writer = BufWriter::new(File::create("example-output-countries.geojson")?);
+    geojson::ser::to_feature_collection_writer(file_writer, &countries)?;
+
+    Ok(())
+}

--- a/examples/deserialize_to_geo_types.rs
+++ b/examples/deserialize_to_geo_types.rs
@@ -1,0 +1,37 @@
+use geojson::{de::deserialize_geometry, ser::serialize_geometry};
+
+use serde::{Deserialize, Serialize};
+use std::error::Error;
+use std::fs::File;
+use std::io::{BufReader, BufWriter};
+
+#[cfg(not(feature="geo-types"))]
+fn main() -> Result<(), Box<dyn Error>> {
+    panic!("this example requires geo-types")
+}
+
+#[cfg(feature="geo-types")]
+fn main() -> Result<(), Box<dyn Error>> {
+    #[derive(Serialize, Deserialize)]
+    struct Country {
+        #[serde(
+            serialize_with = "serialize_geometry",
+            deserialize_with = "deserialize_geometry"
+        )]
+        geometry: geo_types::Geometry,
+        name: String,
+    }
+
+    let file_reader = BufReader::new(File::open("tests/fixtures/countries.geojson")?);
+
+    // Create a Vec of Country structs from the GeoJSON
+    let countries: Vec<Country> =
+        geojson::de::deserialize_feature_collection_to_vec::<Country>(file_reader)?;
+    assert_eq!(countries.len(), 180);
+
+    // Write the structs back to GeoJSON
+    let file_writer = BufWriter::new(File::create("example-output-countries.geojson")?);
+    geojson::ser::to_feature_collection_writer(file_writer, &countries)?;
+
+    Ok(())
+}

--- a/examples/deserialize_to_geojson_types.rs
+++ b/examples/deserialize_to_geojson_types.rs
@@ -1,0 +1,18 @@
+use std::error::Error;
+use std::fs::File;
+use std::io::{BufReader, BufWriter};
+
+use geojson::FeatureCollection;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let file_reader = BufReader::new(File::open("tests/fixtures/countries.geojson")?);
+
+    let countries: FeatureCollection = serde_json::from_reader(file_reader)?;
+    assert_eq!(countries.features.len(), 180);
+
+    // Write the structs back to GeoJSON
+    let file_writer = BufWriter::new(File::create("example-output-countries.geojson")?);
+    serde_json::to_writer(file_writer, &countries)?;
+
+    Ok(())
+}

--- a/src/conversion/mod.rs
+++ b/src/conversion/mod.rs
@@ -63,12 +63,10 @@ macro_rules! assert_almost_eq {
     }};
 }
 
-
 macro_rules! try_from_owned_value {
     ($to:ty) => {
         #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
-        impl<T: CoordFloat> TryFrom<geometry::Value> for $to
-        {
+        impl<T: CoordFloat> TryFrom<geometry::Value> for $to {
             type Error = Error;
 
             fn try_from(value: geometry::Value) -> Result<Self> {
@@ -77,7 +75,6 @@ macro_rules! try_from_owned_value {
         }
     };
 }
-
 
 pub(crate) mod from_geo_types;
 pub(crate) mod to_geo_types;

--- a/src/de.rs
+++ b/src/de.rs
@@ -411,9 +411,6 @@ where
         }
 
         if has_feature_type {
-            // What do I actually do here? serde-transcode? or create a new MapAccess or Struct that
-            // has the fields needed by a child visitor - perhaps using serde::de::value::MapAccessDeserializer?
-            // use serde::de::value::MapAccessDeserializer;
             let d2 = hash_map.into_deserializer();
             let result =
                 Deserialize::deserialize(d2).map_err(|e| Error::custom(format!("{}", e)))?;

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,0 +1,653 @@
+//!
+//! To build instances of your struct from a GeoJSON String or reader, your type *must*
+//! implement or derive [`serde::Deserialize`]:
+//!
+//! ```rust, ignore
+//! #[derive(serde::Deserialize)]
+//! struct MyStruct {
+//!     ...
+//! }
+//! ```
+//!
+//! Your type *must* have a field called `geometry` and it must be `deserialized_with` [`deserialize_geometry`](crate::de::deserialize_geometry):
+//!  ```rust, ignore
+//! #[derive(serde::Deserialize)]
+//! struct MyStruct {
+//!     #[serde(serialize_with = "geojson::de::deserialize_geometry")]
+//!     geometry: geo_types::Point<f64>,
+//!     ...
+//! }
+//! ```
+//!
+//! All fields in your struct other than `geometry` will be deserialized from the `properties` of the
+//! GeoJSON Feature.
+//!
+//! # Examples
+#![cfg_attr(feature = "geo-types", doc = "```")]
+#![cfg_attr(not(feature = "geo-types"), doc = "```ignore")]
+//! use serde::Deserialize;
+//! use geojson::de::deserialize_geometry;
+//!
+//! #[derive(Deserialize)]
+//! struct MyStruct {
+//!     // Deserialize from geojson, rather than expecting the type's default serialization
+//!     #[serde(deserialize_with = "deserialize_geometry")]
+//!     geometry: geo_types::Point<f64>,
+//!     name: String,
+//!     population: u64
+//! }
+//!
+//! let input_geojson = serde_json::json!(
+//!     {
+//!         "type":"FeatureCollection",
+//!         "features": [
+//!             {
+//!                 "type": "Feature",
+//!                 "geometry": { "coordinates": [11.1,22.2], "type": "Point" },
+//!                 "properties": {
+//!                     "name": "Downtown",
+//!                     "population": 123
+//!                 }
+//!             },
+//!             {
+//!                 "type": "Feature",
+//!                 "geometry": { "coordinates": [33.3, 44.4], "type": "Point" },
+//!                 "properties": {
+//!                     "name": "Uptown",
+//!                     "population": 456
+//!                 }
+//!             }
+//!         ]
+//!     }
+//! ).to_string();
+//!
+//! let my_structs: Vec<MyStruct> = geojson::de::deserialize_feature_collection_str_to_vec(&input_geojson).unwrap();
+//! assert_eq!("Downtown", my_structs[0].name);
+//! assert_eq!(11.1, my_structs[0].geometry.x());
+//!
+//! assert_eq!("Uptown", my_structs[1].name);
+//! assert_eq!(33.3, my_structs[1].geometry.x());
+//! ```
+//!
+//! # Reading *and* Writing GeoJSON
+//!
+//! This module is only concerned with _reading in_ GeoJSON. If you'd also like to write GeoJSON
+//! output, you'll want to combine this with the functionality from the [`crate::ser`] module:
+//! ```ignore
+//! #[derive(serde::Serialize, serde::Deserialize)]
+//! struct MyStruct {
+//!     // Serialize as geojson, rather than using the type's default serialization
+//!     #[serde(serialize_with = "serialize_geometry", deserialize_with = "deserialize_geometry")]
+//!     geometry: geo_types::Point<f64>,
+//!     ...
+//! }
+//! ```
+use crate::{Feature, FeatureReader, JsonValue, Result};
+
+use std::convert::{TryFrom, TryInto};
+use std::fmt::Formatter;
+use std::io::Read;
+use std::marker::PhantomData;
+
+use serde::de::{Deserialize, Deserializer, Error, IntoDeserializer};
+
+/// Deserialize a GeoJSON FeatureCollection into your custom structs.
+///
+/// Your struct must implement or derive `serde::Deserialize`.
+///
+/// You must use the [`deserialize_geometry`] helper if you are using geo_types or some other geometry
+/// representation other than geojson::Geometry.
+///
+/// # Examples
+#[cfg_attr(feature = "geo-types", doc = "```")]
+#[cfg_attr(not(feature = "geo-types"), doc = "```ignore")]
+/// use serde::Deserialize;
+/// use geojson::de::deserialize_geometry;
+///
+/// #[derive(Deserialize)]
+/// struct MyStruct {
+///     // You must use the `deserialize_geometry` helper if you are using geo_types or some other
+///     // geometry representation other than geojson::Geometry
+///     #[serde(deserialize_with = "deserialize_geometry")]
+///     geometry: geo_types::Point<f64>,
+///     name: String,
+/// }
+///
+/// let feature_collection_str = r#"{
+///     "type": "FeatureCollection",
+///     "features": [
+///         {
+///             "type": "Feature",
+///             "geometry": { "type": "Point", "coordinates": [11.1, 22.2] },
+///             "properties": { "name": "Downtown" }
+///         },
+///         {
+///             "type": "Feature",
+///             "geometry": { "type": "Point", "coordinates": [33.3, 44.4] },
+///             "properties": { "name": "Uptown" }
+///         }
+///     ]
+/// }"#;
+/// let reader = feature_collection_str.as_bytes();
+///
+/// // enumerate over the features in the feature collection
+/// for (idx, feature_result) in geojson::de::deserialize_feature_collection::<MyStruct>(reader).unwrap().enumerate() {
+///     let my_struct = feature_result.expect("valid geojson for MyStruct");
+///     if idx == 0 {
+///         assert_eq!(my_struct.name, "Downtown");
+///         assert_eq!(my_struct.geometry.x(), 11.1);
+///     } else if idx == 1 {
+///         assert_eq!(my_struct.name, "Uptown");
+///         assert_eq!(my_struct.geometry.x(), 33.3);
+///     } else {
+///         unreachable!("there are only two features in this collection");
+///     }
+/// }
+/// ```
+pub fn deserialize_feature_collection<'de, T>(
+    feature_collection_reader: impl Read,
+) -> Result<impl Iterator<Item = Result<T>>>
+where
+    T: Deserialize<'de>,
+{
+    let mut deserializer = serde_json::Deserializer::from_reader(feature_collection_reader);
+
+    // PERF: rather than deserializing the entirety of the `features:` array into memory here, it'd
+    // be nice to stream the features. However, I ran into difficulty while trying to return any
+    // borrowed reference from the visitor methods (e.g. MapAccess)
+    let visitor = FeatureCollectionVisitor::new();
+    let objects = deserializer.deserialize_map(visitor)?;
+
+    Ok(objects.into_iter().map(|feature_value| {
+        let deserializer = feature_value.into_deserializer();
+        let visitor = FeatureVisitor::new();
+        let record: T = deserializer.deserialize_map(visitor)?;
+
+        Ok(record)
+    }))
+}
+
+/// Build a `Vec` of structs from a GeoJson `&str`.
+///
+/// See [`deserialize_feature_collection`] for more.
+pub fn deserialize_feature_collection_str_to_vec<'de, T>(
+    feature_collection_str: &str,
+) -> Result<Vec<T>>
+where
+    T: Deserialize<'de>,
+{
+    let feature_collection_reader = feature_collection_str.as_bytes();
+    deserialize_feature_collection(feature_collection_reader)?.collect()
+}
+
+/// Build a `Vec` of structs from a GeoJson reader.
+///
+/// See [`deserialize_feature_collection`] for more.
+pub fn deserialize_feature_collection_to_vec<'de, T>(
+    feature_collection_reader: impl Read,
+) -> Result<Vec<T>>
+where
+    T: Deserialize<'de>,
+{
+    deserialize_feature_collection(feature_collection_reader)?.collect()
+}
+
+/// [`serde::deserialize_with`](https://serde.rs/field-attrs.html#deserialize_with) helper to deserialize a GeoJSON Geometry into another type, like a
+/// [`geo_types`] Geometry.
+///
+/// # Examples
+#[cfg_attr(feature = "geo-types", doc = "```")]
+#[cfg_attr(not(feature = "geo-types"), doc = "```ignore")]
+/// use serde::Deserialize;
+/// use geojson::de::deserialize_geometry;
+///
+/// #[derive(Deserialize)]
+/// struct MyStruct {
+///     #[serde(deserialize_with = "deserialize_geometry")]
+///     geometry: geo_types::Point<f64>,
+///     name: String,
+/// }
+///
+/// let feature_collection_str = r#"{
+///     "type": "FeatureCollection",
+///     "features": [
+///         {
+///             "type": "Feature",
+///             "geometry": { "type": "Point", "coordinates": [11.1, 22.2] },
+///             "properties": { "name": "Downtown" }
+///         },
+///         {
+///             "type": "Feature",
+///             "geometry": { "type": "Point", "coordinates": [33.3, 44.4] },
+///             "properties": { "name": "Uptown" }
+///         }
+///     ]
+/// }"#;
+///
+/// let features: Vec<MyStruct> = geojson::de::deserialize_feature_collection_str_to_vec(feature_collection_str).unwrap();
+///
+/// assert_eq!(features[0].name, "Downtown");
+/// assert_eq!(features[0].geometry.x(), 11.1);
+/// ```
+pub fn deserialize_geometry<'de, D, G>(deserializer: D) -> std::result::Result<G, D::Error>
+where
+    D: Deserializer<'de>,
+    G: TryFrom<crate::Geometry>,
+    G::Error: std::fmt::Display,
+{
+    let geojson_geometry = crate::Geometry::deserialize(deserializer)?;
+    geojson_geometry
+        .try_into()
+        .map_err(|err| Error::custom(format!("unable to convert from geojson Geometry: {}", err)))
+}
+
+/// Deserialize a GeoJSON FeatureCollection into [`Feature`] structs.
+///
+/// If instead you'd like to deserialize your own structs from GeoJSON, see [`deserialize_feature_collection`].
+pub fn deserialize_features_from_feature_collection(
+    feature_collection_reader: impl Read,
+) -> impl Iterator<Item = Result<Feature>> {
+    FeatureReader::from_reader(feature_collection_reader).features()
+}
+
+/// Deserialize a single GeoJSON Feature into your custom struct.
+///
+/// It's more common to deserialize a FeatureCollection than a single feature. If you're looking to
+/// do that, see [`deserialize_feature_collection`] instead.
+///
+/// Your struct must implement or derive `serde::Deserialize`.
+///
+/// # Examples
+#[cfg_attr(feature = "geo-types", doc = "```")]
+#[cfg_attr(not(feature = "geo-types"), doc = "```ignore")]
+/// use serde::Deserialize;
+/// use geojson::de::deserialize_geometry;
+///
+/// #[derive(Deserialize)]
+/// struct MyStruct {
+///     // You must use the `deserialize_geometry` helper if you are using geo_types or some other
+///     // geometry representation other than geojson::Geometry
+///     #[serde(deserialize_with = "deserialize_geometry")]
+///     geometry: geo_types::Point<f64>,
+///     name: String,
+/// }
+///
+/// let feature_str = r#"{
+///     "type": "Feature",
+///     "geometry": { "type": "Point", "coordinates": [11.1, 22.2] },
+///     "properties": { "name": "Downtown" }
+/// }"#;
+/// let reader = feature_str.as_bytes();
+///
+/// // build your struct from GeoJSON
+/// let my_struct = geojson::de::deserialize_single_feature::<MyStruct>(reader).expect("valid geojson for MyStruct");
+///
+/// assert_eq!(my_struct.name, "Downtown");
+/// assert_eq!(my_struct.geometry.x(), 11.1);
+/// ```
+pub fn deserialize_single_feature<'de, T>(feature_reader: impl Read) -> Result<T>
+where
+    T: Deserialize<'de>,
+{
+    let feature_value: JsonValue = serde_json::from_reader(feature_reader)?;
+    let deserializer = feature_value.into_deserializer();
+    let visitor = FeatureVisitor::new();
+    Ok(deserializer.deserialize_map(visitor)?)
+}
+
+struct FeatureCollectionVisitor;
+
+impl FeatureCollectionVisitor {
+    fn new() -> Self {
+        Self
+    }
+}
+
+impl<'de> serde::de::Visitor<'de> for FeatureCollectionVisitor {
+    type Value = Vec<JsonValue>;
+
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+        write!(formatter, "a valid GeoJSON Feature object")
+    }
+
+    fn visit_map<A>(self, mut map_access: A) -> std::result::Result<Self::Value, A::Error>
+    where
+        A: serde::de::MapAccess<'de>,
+    {
+        let mut has_feature_collection_type = false;
+        let mut features = None;
+        while let Some((key, value)) = map_access.next_entry::<String, JsonValue>()? {
+            if key == "type" {
+                if value == JsonValue::String("FeatureCollection".to_string()) {
+                    has_feature_collection_type = true;
+                } else {
+                    return Err(Error::custom("invalid type for feature collection"));
+                }
+            } else if key == "features" {
+                if let JsonValue::Array(value) = value {
+                    if features.is_some() {
+                        return Err(Error::custom(
+                            "Encountered more than one list of `features`",
+                        ));
+                    }
+                    features = Some(value);
+                } else {
+                    return Err(Error::custom("`features` had unexpected value"));
+                }
+            } else {
+                log::warn!("foreign members are not handled by FeatureCollection deserializer")
+            }
+        }
+
+        if let Some(features) = features {
+            if has_feature_collection_type {
+                Ok(features)
+            } else {
+                Err(Error::custom("No `type` field was found"))
+            }
+        } else {
+            Err(Error::custom("No `features` field was found"))
+        }
+    }
+}
+
+struct FeatureVisitor<D> {
+    _marker: PhantomData<D>,
+}
+
+impl<D> FeatureVisitor<D> {
+    fn new() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'de, D> serde::de::Visitor<'de> for FeatureVisitor<D>
+where
+    D: Deserialize<'de>,
+{
+    type Value = D;
+
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+        write!(formatter, "a valid GeoJSON Feature object")
+    }
+
+    fn visit_map<A>(self, mut map_access: A) -> std::result::Result<Self::Value, A::Error>
+    where
+        A: serde::de::MapAccess<'de>,
+    {
+        let mut has_feature_type = false;
+        use std::collections::HashMap;
+        let mut hash_map: HashMap<String, JsonValue> = HashMap::new();
+
+        while let Some((key, value)) = map_access.next_entry::<String, JsonValue>()? {
+            if key == "type" {
+                if value.as_str() == Some("Feature") {
+                    has_feature_type = true;
+                } else {
+                    return Err(Error::custom(
+                        "GeoJSON Feature had a `type` other than \"Feature\"",
+                    ));
+                }
+            } else if key == "geometry" {
+                if let JsonValue::Object(_) = value {
+                    hash_map.insert("geometry".to_string(), value);
+                } else {
+                    return Err(Error::custom("GeoJSON Feature had a unexpected geometry"));
+                }
+            } else if key == "properties" {
+                if let JsonValue::Object(properties) = value {
+                    // flatten properties onto struct
+                    for (prop_key, prop_value) in properties {
+                        hash_map.insert(prop_key, prop_value);
+                    }
+                } else {
+                    return Err(Error::custom("GeoJSON Feature had a unexpected geometry"));
+                }
+            } else {
+                log::debug!("foreign members are not handled by Feature deserializer")
+            }
+        }
+
+        if has_feature_type {
+            // What do I actually do here? serde-transcode? or create a new MapAccess or Struct that
+            // has the fields needed by a child visitor - perhaps using serde::de::value::MapAccessDeserializer?
+            // use serde::de::value::MapAccessDeserializer;
+            let d2 = hash_map.into_deserializer();
+            let result =
+                Deserialize::deserialize(d2).map_err(|e| Error::custom(format!("{}", e)))?;
+            Ok(result)
+        } else {
+            Err(Error::custom(
+                "A GeoJSON Feature must have a `type: \"Feature\"` field, but found none.",
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+
+    use crate::JsonValue;
+
+    use serde::Deserialize;
+    use serde_json::json;
+
+    pub(crate) fn feature_collection() -> JsonValue {
+        json!({
+            "type": "FeatureCollection",
+            "features": [
+                {
+                  "type": "Feature",
+                  "geometry": {
+                    "type": "Point",
+                    "coordinates": [125.6, 10.1]
+                  },
+                  "properties": {
+                    "name": "Dinagat Islands",
+                    "age": 123
+                  }
+                },
+                {
+                  "type": "Feature",
+                  "geometry": {
+                    "type": "Point",
+                    "coordinates": [2.3, 4.5]
+                  },
+                  "properties": {
+                    "name": "Neverland",
+                    "age": 456
+                  }
+                }
+            ]
+        })
+    }
+
+    #[test]
+    fn test_deserialize_feature_collection() {
+        use crate::Feature;
+
+        let feature_collection_string = feature_collection().to_string();
+        let bytes_reader = feature_collection_string.as_bytes();
+
+        let records: Vec<Feature> = deserialize_features_from_feature_collection(bytes_reader)
+            .map(|feature_result: Result<Feature>| feature_result.unwrap())
+            .collect();
+
+        assert_eq!(records.len(), 2);
+        let first_age = {
+            let props = records.get(0).unwrap().properties.as_ref().unwrap();
+            props.get("age").unwrap().as_i64().unwrap()
+        };
+        assert_eq!(first_age, 123);
+
+        let second_age = {
+            let props = records.get(1).unwrap().properties.as_ref().unwrap();
+            props.get("age").unwrap().as_i64().unwrap()
+        };
+        assert_eq!(second_age, 456);
+    }
+
+    #[cfg(feature = "geo-types")]
+    mod geo_types_tests {
+        use super::*;
+
+        #[test]
+        fn geometry_field() {
+            #[derive(Deserialize)]
+            struct MyStruct {
+                #[serde(deserialize_with = "deserialize_geometry")]
+                geometry: geo_types::Geometry<f64>,
+                name: String,
+                age: u64,
+            }
+
+            let feature_collection_string = feature_collection().to_string();
+            let bytes_reader = feature_collection_string.as_bytes();
+
+            let records: Vec<MyStruct> = deserialize_feature_collection(bytes_reader)
+                .expect("a valid feature collection")
+                .collect::<Result<Vec<_>>>()
+                .expect("valid features");
+
+            assert_eq!(records.len(), 2);
+
+            assert_eq!(
+                records[0].geometry,
+                geo_types::point!(x: 125.6, y: 10.1).into()
+            );
+            assert_eq!(records[0].name, "Dinagat Islands");
+            assert_eq!(records[0].age, 123);
+
+            assert_eq!(
+                records[1].geometry,
+                geo_types::point!(x: 2.3, y: 4.5).into()
+            );
+            assert_eq!(records[1].name, "Neverland");
+            assert_eq!(records[1].age, 456);
+        }
+
+        #[test]
+        fn specific_geometry_variant_field() {
+            #[derive(Deserialize)]
+            struct MyStruct {
+                #[serde(deserialize_with = "deserialize_geometry")]
+                geometry: geo_types::Point<f64>,
+                name: String,
+                age: u64,
+            }
+
+            let feature_collection_string = feature_collection().to_string();
+            let bytes_reader = feature_collection_string.as_bytes();
+
+            let records: Vec<MyStruct> = deserialize_feature_collection(bytes_reader)
+                .expect("a valid feature collection")
+                .collect::<Result<Vec<_>>>()
+                .expect("valid features");
+
+            assert_eq!(records.len(), 2);
+
+            assert_eq!(records[0].geometry, geo_types::point!(x: 125.6, y: 10.1));
+            assert_eq!(records[0].name, "Dinagat Islands");
+            assert_eq!(records[0].age, 123);
+
+            assert_eq!(records[1].geometry, geo_types::point!(x: 2.3, y: 4.5));
+            assert_eq!(records[1].name, "Neverland");
+            assert_eq!(records[1].age, 456);
+        }
+
+        #[test]
+        fn wrong_geometry_variant_field() {
+            #[allow(unused)]
+            #[derive(Deserialize)]
+            struct MyStruct {
+                #[serde(deserialize_with = "deserialize_geometry")]
+                geometry: geo_types::LineString<f64>,
+                name: String,
+                age: u64,
+            }
+
+            let feature_collection_string = feature_collection().to_string();
+            let bytes_reader = feature_collection_string.as_bytes();
+
+            let records: Vec<Result<MyStruct>> = deserialize_feature_collection(bytes_reader)
+                .unwrap()
+                .collect();
+            assert_eq!(records.len(), 2);
+            assert!(records[0].is_err());
+            assert!(records[1].is_err());
+
+            let err = match records[0].as_ref() {
+                Ok(_ok) => panic!("expected Err, but found OK"),
+                Err(e) => e,
+            };
+
+            // This will fail if we update our error text, but I wanted to show that the error text
+            // is reasonably discernible.
+            let expected_err_text = r#"Error while deserializing JSON: unable to convert from geojson Geometry: Encountered a mismatch when converting to a Geo type: `{"coordinates":[125.6,10.1],"type":"Point"}`"#;
+            assert_eq!(err.to_string(), expected_err_text);
+        }
+    }
+
+    #[cfg(feature = "geo-types")]
+    #[test]
+    fn roundtrip() {
+        use crate::ser::serialize_geometry;
+        use serde::Serialize;
+
+        #[derive(Serialize, Deserialize)]
+        struct MyStruct {
+            #[serde(
+                serialize_with = "serialize_geometry",
+                deserialize_with = "deserialize_geometry"
+            )]
+            geometry: geo_types::Point<f64>,
+            name: String,
+            age: u64,
+        }
+
+        let feature_collection_string = feature_collection().to_string();
+        let bytes_reader = feature_collection_string.as_bytes();
+
+        let mut elements = deserialize_feature_collection_to_vec::<MyStruct>(bytes_reader).unwrap();
+        for element in &mut elements {
+            element.age += 1;
+            element.geometry.set_x(element.geometry.x() + 1.0);
+        }
+        let actual_output = crate::ser::to_feature_collection_string(&elements).unwrap();
+
+        use std::str::FromStr;
+        let actual_output_json = JsonValue::from_str(&actual_output).unwrap();
+        let expected_output_json = json!({
+            "type": "FeatureCollection",
+            "features": [
+                {
+                  "type": "Feature",
+                  "geometry": {
+                    "type": "Point",
+                    "coordinates": [126.6, 10.1]
+                  },
+                  "properties": {
+                    "name": "Dinagat Islands",
+                    "age": 124
+                  }
+                },
+                {
+                  "type": "Feature",
+                  "geometry": {
+                    "type": "Point",
+                    "coordinates": [3.3, 4.5]
+                  },
+                  "properties": {
+                    "name": "Neverland",
+                    "age": 457
+                  }
+                }
+            ]
+        });
+
+        assert_eq!(actual_output_json, expected_output_json);
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -21,6 +21,8 @@ pub enum Error {
     /// This was previously `GeoJsonUnknownType`, but has been split for clarity
     #[error("Expected a Feature mapping, but got a `{0}`")]
     NotAFeature(String),
+    // TODO: Expect vs. Found (and maybe it doesn't need to be "geo-type" specific, but anything
+    // that can be converted)?
     #[error("Encountered a mismatch when converting to a Geo type: `{0}`")]
     InvalidGeometryConversion(GValue),
     #[error(
@@ -29,7 +31,7 @@ pub enum Error {
     FeatureHasNoGeometry(Feature),
     #[error("Encountered an unknown 'geometry' object type: `{0}`")]
     GeometryUnknownType(String),
-    #[error("Encountered malformed JSON: {0}")]
+    #[error("Error while deserializing JSON: {0}")]
     MalformedJson(serde_json::Error),
     #[error("Encountered neither object type nor null type for 'properties' object: `{0}`")]
     PropertiesExpectedObjectOrNull(Value),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -21,8 +21,6 @@ pub enum Error {
     /// This was previously `GeoJsonUnknownType`, but has been split for clarity
     #[error("Expected a Feature mapping, but got a `{0}`")]
     NotAFeature(String),
-    // TODO: Expect vs. Found (and maybe it doesn't need to be "geo-type" specific, but anything
-    // that can be converted)?
     #[error("Encountered a mismatch when converting to a Geo type: `{0}`")]
     InvalidGeometryConversion(GValue),
     #[error(

--- a/src/feature_iterator.rs
+++ b/src/feature_iterator.rs
@@ -11,12 +11,18 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![allow(deprecated)]
 
 use crate::{Feature, Result};
 
 use std::io;
 use std::marker::PhantomData;
 
+// TODO: Eventually make this private - and expose only FeatureReader.
+#[deprecated(
+    since = "0.24.0",
+    note = "use FeatureReader::from_reader(io).features() instead"
+)]
 /// Iteratively deserialize individual features from a stream containing a
 /// GeoJSON [`FeatureCollection`](struct@crate::FeatureCollection)
 ///

--- a/src/feature_reader.rs
+++ b/src/feature_reader.rs
@@ -1,0 +1,271 @@
+use crate::de::deserialize_feature_collection;
+use crate::{Feature, Result};
+
+use serde::de::DeserializeOwned;
+
+use std::io::Read;
+
+pub struct FeatureReader<R> {
+    reader: R,
+}
+
+impl<R: Read> FeatureReader<R> {
+    pub fn from_reader(reader: R) -> Self {
+        Self { reader }
+    }
+
+    /// Iterate over the individual [`Feature`s](Feature) of a FeatureCollection
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let feature_collection_string = r#"{
+    ///      "type": "FeatureCollection",
+    ///      "features": [
+    ///          {
+    ///            "type": "Feature",
+    ///            "geometry": {
+    ///              "type": "Point",
+    ///              "coordinates": [125.6, 10.1]
+    ///            },
+    ///            "properties": {
+    ///              "name": "Dinagat Islands",
+    ///              "age": 123
+    ///            }
+    ///          },
+    ///          {
+    ///            "type": "Feature",
+    ///            "geometry": {
+    ///              "type": "Point",
+    ///              "coordinates": [2.3, 4.5]
+    ///            },
+    ///            "properties": {
+    ///              "name": "Neverland",
+    ///              "age": 456
+    ///            }
+    ///          }
+    ///      ]
+    /// }"#
+    /// .as_bytes();
+    /// let io_reader = std::io::BufReader::new(feature_collection_string);
+    ///
+    /// use geojson::FeatureReader;
+    /// let feature_reader = FeatureReader::from_reader(io_reader);
+    /// for feature in feature_reader.features() {
+    ///     let feature = feature.expect("valid geojson feature");
+    ///
+    ///     let name = feature.property("name").unwrap().as_str().unwrap();
+    ///     let age = feature.property("age").unwrap().as_u64().unwrap();
+    ///
+    ///     if name == "Dinagat Islands" {
+    ///         assert_eq!(123, age);
+    ///     } else if name == "Neverland" {
+    ///         assert_eq!(456, age);
+    ///     } else {
+    ///         panic!("unexpected name: {}", name);
+    ///     }
+    /// }
+    /// ```
+    pub fn features(self) -> impl Iterator<Item = Result<Feature>> {
+        crate::FeatureIterator::new(self.reader)
+    }
+
+    /// Deserialize the features of FeatureCollection into your own custom
+    /// struct using the [`serde`](../../serde) crate.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let feature_collection_string = r#"{
+    ///     "type": "FeatureCollection",
+    ///     "features": [
+    ///         {
+    ///            "type": "Feature",
+    ///            "geometry": {
+    ///              "type": "Point",
+    ///              "coordinates": [125.6, 10.1]
+    ///            },
+    ///            "properties": {
+    ///              "name": "Dinagat Islands",
+    ///              "age": 123
+    ///            }
+    ///         },
+    ///         {
+    ///            "type": "Feature",
+    ///            "geometry": {
+    ///              "type": "Point",
+    ///              "coordinates": [2.3, 4.5]
+    ///            },
+    ///            "properties": {
+    ///              "name": "Neverland",
+    ///              "age": 456
+    ///            }
+    ///          }
+    ///    ]
+    /// }"#
+    /// .as_bytes();
+    /// let io_reader = std::io::BufReader::new(feature_collection_string);
+    ///
+    /// use serde::Deserialize;
+    /// #[derive(Debug, Deserialize)]
+    /// struct MyStruct {
+    ///     geometry: geojson::Geometry,
+    ///     name: String,
+    ///     age: u64,
+    /// }
+    ///
+    /// use geojson::FeatureReader;
+    /// use geojson::GeoJson::Geometry;
+    /// let feature_reader = FeatureReader::from_reader(io_reader);
+    /// for feature in feature_reader.deserialize::<MyStruct>().unwrap() {
+    ///     let my_struct = feature.expect("valid geojson feature");
+    ///
+    ///     if my_struct.name == "Dinagat Islands" {
+    ///         assert_eq!(123, my_struct.age);
+    ///     } else if my_struct.name == "Neverland" {
+    ///         assert_eq!(456, my_struct.age);
+    ///     } else {
+    ///         panic!("unexpected name: {}", my_struct.name);
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ## With geo-types Geometry
+    #[cfg_attr(feature = "geo-types", doc = "```")]
+    #[cfg_attr(not(feature = "geo-types"), doc = "```ignore")]
+    /// let feature_collection_string = r#"{
+    ///     "type": "FeatureCollection",
+    ///     "features": [
+    ///         {
+    ///            "type": "Feature",
+    ///            "geometry": {
+    ///              "type": "Point",
+    ///              "coordinates": [125.6, 10.1]
+    ///            },
+    ///            "properties": {
+    ///              "name": "Dinagat Islands",
+    ///              "age": 123
+    ///            }
+    ///         },
+    ///         {
+    ///            "type": "Feature",
+    ///            "geometry": {
+    ///              "type": "Point",
+    ///              "coordinates": [2.3, 4.5]
+    ///            },
+    ///            "properties": {
+    ///              "name": "Neverland",
+    ///              "age": 456
+    ///            }
+    ///          }
+    ///    ]
+    /// }"#
+    /// .as_bytes();
+    ///
+    /// let io_reader = std::io::BufReader::new(feature_collection_string);
+    ///
+    /// use geojson::de::deserialize_geometry;
+    /// use geojson::FeatureReader;
+    /// use serde::Deserialize;
+    ///
+    /// #[derive(Debug, Deserialize)]
+    /// struct MyStruct {
+    ///     #[serde(deserialize_with = "deserialize_geometry")]
+    ///     geometry: geo_types::Geometry<f64>,
+    ///     name: String,
+    ///     age: u64,
+    /// }
+    ///
+    /// let feature_reader = FeatureReader::from_reader(io_reader);
+    /// for feature in feature_reader.deserialize::<MyStruct>().unwrap() {
+    ///     let my_struct = feature.expect("valid geojson feature");
+    ///
+    ///     if my_struct.name == "Dinagat Islands" {
+    ///         assert_eq!(123, my_struct.age);
+    ///     } else if my_struct.name == "Neverland" {
+    ///         assert_eq!(456, my_struct.age);
+    ///     } else {
+    ///         panic!("unexpected name: {}", my_struct.name);
+    ///     }
+    /// }
+    /// ```
+    pub fn deserialize<D: DeserializeOwned>(self) -> Result<impl Iterator<Item = Result<D>>> {
+        deserialize_feature_collection(self.reader)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use serde::Deserialize;
+    use serde_json::json;
+
+    #[derive(Deserialize)]
+    struct MyRecord {
+        geometry: crate::Geometry,
+        name: String,
+        age: u64,
+    }
+
+    fn feature_collection_string() -> String {
+        json!({
+            "type": "FeatureCollection",
+            "features": [
+                {
+                  "type": "Feature",
+                  "geometry": {
+                    "type": "Point",
+                    "coordinates": [125.6, 10.1]
+                  },
+                  "properties": {
+                    "name": "Dinagat Islands",
+                    "age": 123
+                  }
+                },
+                {
+                  "type": "Feature",
+                  "geometry": {
+                    "type": "Point",
+                    "coordinates": [2.3, 4.5]
+                  },
+                  "properties": {
+                    "name": "Neverland",
+                    "age": 456
+                  }
+                }
+            ]
+        })
+        .to_string()
+    }
+
+    #[test]
+    #[cfg(feature = "geo-types")]
+    fn deserialize_into_type() {
+        let feature_collection_string = feature_collection_string();
+        let mut bytes_reader = feature_collection_string.as_bytes();
+        let feature_reader = FeatureReader::from_reader(&mut bytes_reader);
+
+        let records: Vec<MyRecord> = feature_reader
+            .deserialize()
+            .expect("a valid feature collection")
+            .map(|result| result.expect("a valid feature"))
+            .collect();
+
+        assert_eq!(records.len(), 2);
+
+        assert_eq!(
+            records[0].geometry,
+            (&geo_types::point!(x: 125.6, y: 10.1)).into()
+        );
+        assert_eq!(records[0].name, "Dinagat Islands");
+        assert_eq!(records[0].age, 123);
+
+        assert_eq!(
+            records[1].geometry,
+            (&geo_types::point!(x: 2.3, y: 4.5)).into()
+        );
+        assert_eq!(records[1].name, "Neverland");
+        assert_eq!(records[1].age, 456);
+    }
+}

--- a/src/feature_reader.rs
+++ b/src/feature_reader.rs
@@ -65,6 +65,7 @@ impl<R: Read> FeatureReader<R> {
     /// }
     /// ```
     pub fn features(self) -> impl Iterator<Item = Result<Feature>> {
+        #[allow(deprecated)]
         crate::FeatureIterator::new(self.reader)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -419,6 +419,16 @@ pub use crate::errors::{Error, Result};
 #[cfg(feature = "geo-types")]
 mod conversion;
 
+/// Build your struct from GeoJSON using [`serde`]
+pub mod de;
+
+/// Write your struct to GeoJSON using [`serde`]
+pub mod ser;
+
+mod feature_reader;
+
+pub use feature_reader::FeatureReader;
+
 #[cfg(feature = "geo-types")]
 pub use conversion::quick_collection;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -411,6 +411,8 @@ mod feature_collection;
 pub use crate::feature_collection::FeatureCollection;
 
 mod feature_iterator;
+#[allow(deprecated)]
+#[doc(hidden)]
 pub use crate::feature_iterator::FeatureIterator;
 
 pub mod errors;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,0 +1,599 @@
+//!
+//! To output your struct to GeoJSON, either as a String, bytes, or to a file, your type *must*
+//! implement or derive [`serde::Serialize`]:
+//!
+//! ```rust, ignore
+//! #[derive(serde::Serialize)]
+//! struct MyStruct {
+//!     ...
+//! }
+//! ```
+//!
+//! Your type *must* have a field called `geometry` and it must be `serialized_with` [`serialize_geometry`](crate::ser::serialize_geometry):
+//!  ```rust, ignore
+//! #[derive(serde::Serialize)]
+//! struct MyStruct {
+//!     #[serde(serialize_with = "geojson::ser::serialize_geometry")]
+//!     geometry: geo_types::Point<f64>,
+//!     ...
+//! }
+//! ```
+//!
+//! All fields in your struct other than `geometry` will be serialized as `properties` of the
+//! GeoJSON Feature.
+//!
+//! # Examples
+#![cfg_attr(feature = "geo-types", doc = "```")]
+#![cfg_attr(not(feature = "geo-types"), doc = "```ignore")]
+//! use serde::Serialize;
+//! use geojson::ser::serialize_geometry;
+//!
+//! #[derive(Serialize)]
+//! struct MyStruct {
+//!     // Serialize as geojson, rather than using the type's default serialization
+//!     #[serde(serialize_with = "serialize_geometry")]
+//!     geometry: geo_types::Point<f64>,
+//!     name: String,
+//!     population: u64
+//! }
+//!
+//! let my_structs = vec![
+//!     MyStruct {
+//!         geometry: geo_types::Point::new(11.1, 22.2),
+//!         name: "Downtown".to_string(),
+//!         population: 123
+//!     },
+//!     MyStruct {
+//!         geometry: geo_types::Point::new(33.3, 44.4),
+//!         name: "Uptown".to_string(),
+//!         population: 456
+//!     }
+//! ];
+//!
+//! let output_geojson = geojson::ser::to_feature_collection_string(&my_structs).unwrap();
+//!
+//! let expected_geojson = serde_json::json!(
+//!     {
+//!         "type":"FeatureCollection",
+//!         "features": [
+//!             {
+//!                 "type": "Feature",
+//!                 "geometry": { "coordinates": [11.1,22.2], "type": "Point" },
+//!                 "properties": {
+//!                     "name": "Downtown",
+//!                     "population": 123
+//!                 }
+//!             },
+//!             {
+//!                 "type": "Feature",
+//!                 "geometry": { "coordinates": [33.3, 44.4], "type": "Point" },
+//!                 "properties": {
+//!                     "name": "Uptown",
+//!                     "population": 456
+//!                 }
+//!             }
+//!         ]
+//!     }
+//! );
+//! #
+//! # // re-parse the json to do a structural comparison, rather than worry about formatting
+//! # // or other meaningless deviations in an exact String comparison.
+//! # let output_geojson: serde_json::Value = serde_json::from_str(&output_geojson).unwrap();
+//! #
+//! # assert_eq!(output_geojson, expected_geojson);
+//! ```
+//!
+//! # Reading *and* Writing GeoJSON
+//!
+//! This module is only concerned with Writing out GeoJSON. If you'd also like to reading GeoJSON,
+//! you'll want to combine this with the functionality from the [`crate::de`] module:
+//! ```ignore
+//! #[derive(serde::Serialize, serde::Deserialize)]
+//! struct MyStruct {
+//!     // Serialize as geojson, rather than using the type's default serialization
+//!     #[serde(serialize_with = "serialize_geometry", deserialize_with = "deserialize_geometry")]
+//!     geometry: geo_types::Point<f64>,
+//!     ...
+//! }
+//! ```
+use crate::{JsonObject, Result};
+
+use serde::{ser::Error, Serialize, Serializer};
+
+use std::io;
+
+/// Serialize a single data structure to a GeoJSON Feature string.
+///
+/// Note that `T` must have a column called `geometry`.
+///
+/// See [`to_feature_collection_string`] if instead you'd like to serialize multiple features to a
+/// FeatureCollection.
+///
+/// # Errors
+///
+/// Serialization can fail if `T`'s implementation of `Serialize` decides to
+/// fail, or if `T` contains a map with non-string keys.
+pub fn to_feature_string<T>(value: &T) -> Result<String>
+where
+    T: Serialize,
+{
+    let vec = to_feature_byte_vec(value)?;
+    let string = unsafe {
+        // We do not emit invalid UTF-8.
+        String::from_utf8_unchecked(vec)
+    };
+    Ok(string)
+}
+
+/// Serialize elements to a GeoJSON FeatureCollection string.
+///
+/// Note that `T` must have a column called `geometry`.
+///
+/// # Errors
+///
+/// Serialization can fail if `T`'s implementation of `Serialize` decides to
+/// fail, or if `T` contains a map with non-string keys.
+pub fn to_feature_collection_string<T>(values: &[T]) -> Result<String>
+where
+    T: Serialize,
+{
+    let vec = to_feature_collection_byte_vec(values)?;
+    let string = unsafe {
+        // We do not emit invalid UTF-8.
+        String::from_utf8_unchecked(vec)
+    };
+    Ok(string)
+}
+
+/// Serialize a single data structure to a GeoJSON Feature byte vector.
+///
+/// Note that `T` must have a column called `geometry`.
+///
+/// # Errors
+///
+/// Serialization can fail if `T`'s implementation of `Serialize` decides to
+/// fail, or if `T` contains a map with non-string keys.
+pub fn to_feature_byte_vec<T>(value: &T) -> Result<Vec<u8>>
+where
+    T: Serialize,
+{
+    let mut writer = Vec::with_capacity(128);
+    to_feature_writer(&mut writer, value)?;
+    Ok(writer)
+}
+
+/// Serialize elements to a GeoJSON FeatureCollection byte vector.
+///
+/// Note that `T` must have a column called `geometry`.
+///
+/// # Errors
+///
+/// Serialization can fail if `T`'s implementation of `Serialize` decides to
+/// fail, or if `T` contains a map with non-string keys.
+pub fn to_feature_collection_byte_vec<T>(values: &[T]) -> Result<Vec<u8>>
+where
+    T: Serialize,
+{
+    let mut writer = Vec::with_capacity(128);
+    to_feature_collection_writer(&mut writer, values)?;
+    Ok(writer)
+}
+
+/// Serialize a single data structure as a GeoJSON Feature into the IO stream.
+///
+/// Note that `T` must have a column called `geometry`.
+///
+/// # Errors
+///
+/// Serialization can fail if `T`'s implementation of `Serialize` decides to
+/// fail, or if `T` contains a map with non-string keys.
+pub fn to_feature_writer<W, T>(writer: W, value: &T) -> Result<()>
+where
+    W: io::Write,
+    T: Serialize,
+{
+    let feature_serializer = FeatureWrapper::new(value);
+    let mut serializer = serde_json::Serializer::new(writer);
+    feature_serializer.serialize(&mut serializer)?;
+    Ok(())
+}
+
+/// Serialize elements as a GeoJSON FeatureCollection into the IO stream.
+///
+/// Note that `T` must have a column called `geometry`.
+///
+/// # Errors
+///
+/// Serialization can fail if `T`'s implementation of `Serialize` decides to
+/// fail, or if `T` contains a map with non-string keys.
+pub fn to_feature_collection_writer<W, T>(writer: W, features: &[T]) -> Result<()>
+where
+    W: io::Write,
+    T: Serialize,
+{
+    use serde::ser::SerializeMap;
+
+    let mut ser = serde_json::Serializer::new(writer);
+    let mut map = ser.serialize_map(Some(2))?;
+    map.serialize_entry("type", "FeatureCollection")?;
+    map.serialize_entry("features", &Features::new(features))?;
+    map.end()?;
+    Ok(())
+}
+
+/// [`serde::serialize_with`](https://serde.rs/field-attrs.html#serialize_with) helper to serialize a type like a
+/// [`geo_types`], as a GeoJSON Geometry.
+///
+/// # Examples
+#[cfg_attr(feature = "geo-types", doc = "```")]
+#[cfg_attr(not(feature = "geo-types"), doc = "```ignore")]
+/// use serde::Serialize;
+/// use geojson::ser::serialize_geometry;
+///
+/// #[derive(Serialize)]
+/// struct MyStruct {
+///     // Serialize as geojson, rather than using the type's default serialization
+///     #[serde(serialize_with = "serialize_geometry")]
+///     geometry: geo_types::Point<f64>,
+///     name: String,
+/// }
+///
+/// let my_structs = vec![
+///     MyStruct {
+///         geometry: geo_types::Point::new(11.1, 22.2),
+///         name: "Downtown".to_string()
+///     },
+///     MyStruct {
+///         geometry: geo_types::Point::new(33.3, 44.4),
+///         name: "Uptown".to_string()
+///     }
+/// ];
+///
+/// let geojson_string = geojson::ser::to_feature_collection_string(&my_structs).unwrap();
+///
+/// assert!(geojson_string.contains(r#""geometry":{"coordinates":[11.1,22.2],"type":"Point"}"#));
+/// ```
+pub fn serialize_geometry<IG, S>(geometry: IG, ser: S) -> std::result::Result<S::Ok, S::Error>
+where
+    IG: std::convert::TryInto<crate::Geometry>,
+    S: serde::Serializer,
+{
+    geometry
+        .try_into()
+        .map_err(|_e| Error::custom("failed to convert geometry to geojson"))
+        .and_then(|geojson_geometry| geojson_geometry.serialize(ser))
+}
+
+struct Features<'a, T>
+where
+    T: Serialize,
+{
+    features: &'a [T],
+}
+
+impl<'a, T> Features<'a, T>
+where
+    T: Serialize,
+{
+    fn new(features: &'a [T]) -> Self {
+        Self { features }
+    }
+}
+
+impl<'a, T> serde::Serialize for Features<'a, T>
+where
+    T: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::SerializeSeq;
+        let mut seq = serializer.serialize_seq(None)?;
+        for feature in self.features.iter() {
+            seq.serialize_element(&FeatureWrapper::new(feature))?;
+        }
+        seq.end()
+    }
+}
+
+struct FeatureWrapper<'t, T> {
+    feature: &'t T,
+}
+
+impl<'t, T> FeatureWrapper<'t, T> {
+    fn new(feature: &'t T) -> Self {
+        Self { feature }
+    }
+}
+
+impl<T> Serialize for FeatureWrapper<'_, T>
+where
+    T: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut json_object: JsonObject = {
+            // PERF: this is an extra round-trip just to juggle some fields around.
+            // How can we skip this?
+            let bytes = serde_json::to_vec(self.feature)
+                .map_err(|e| S::Error::custom(format!("unable to serialize to json: {}", e)))?;
+            serde_json::from_slice(&bytes)
+                .map_err(|e| S::Error::custom(format!("unable to roundtrip from json: {}", e)))?
+        };
+
+        if !json_object.contains_key("geometry") {
+            // Currently it's *required* that the struct's geometry field be named `geometry`.
+            //
+            // A likely failure case for users is naming it anything else, e.g. `point: geo::Point`.
+            //
+            // We could just silently blunder on and set `geometry` to None in that case, but
+            // printing a specific error message seems more likely to be helpful.
+            return Err(S::Error::custom("missing `geometry` field"));
+        }
+        let geometry = json_object.remove("geometry");
+
+        use serde::ser::SerializeMap;
+        let mut map = serializer.serialize_map(Some(3))?;
+        map.serialize_entry("type", "Feature")?;
+        map.serialize_entry("geometry", &geometry)?;
+        map.serialize_entry("properties", &json_object)?;
+        map.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::JsonValue;
+
+    use serde_json::json;
+
+    use std::str::FromStr;
+
+    #[test]
+    fn happy_path() {
+        #[derive(Serialize)]
+        struct MyStruct {
+            geometry: crate::Geometry,
+            name: String,
+        }
+
+        let my_feature = {
+            let geometry = crate::Geometry::new(crate::Value::Point(vec![0.0, 1.0]));
+            let name = "burbs".to_string();
+            MyStruct { geometry, name }
+        };
+
+        let expected_output_json = json!({
+            "type": "Feature",
+            "geometry": {
+                "coordinates":[0.0,1.0],
+                "type":"Point"
+            },
+            "properties": {
+                "name": "burbs"
+            }
+        });
+
+        let actual_output = to_feature_string(&my_feature).unwrap();
+        let actual_output_json = JsonValue::from_str(&actual_output).unwrap();
+        assert_eq!(actual_output_json, expected_output_json);
+    }
+
+    mod optional_geometry {
+        use super::*;
+        #[derive(Serialize)]
+        struct MyStruct {
+            geometry: Option<crate::Geometry>,
+            name: String,
+        }
+
+        #[test]
+        fn with_some_geom() {
+            let my_feature = {
+                let geometry = Some(crate::Geometry::new(crate::Value::Point(vec![0.0, 1.0])));
+                let name = "burbs".to_string();
+                MyStruct { geometry, name }
+            };
+
+            let expected_output_json = json!({
+                "type": "Feature",
+                "geometry": {
+                    "coordinates":[0.0,1.0],
+                    "type":"Point"
+                },
+                "properties": {
+                    "name": "burbs"
+                }
+            });
+
+            let actual_output = to_feature_string(&my_feature).unwrap();
+            let actual_output_json = JsonValue::from_str(&actual_output).unwrap();
+            assert_eq!(actual_output_json, expected_output_json);
+        }
+
+        #[test]
+        fn with_none_geom() {
+            let my_feature = {
+                let geometry = None;
+                let name = "burbs".to_string();
+                MyStruct { geometry, name }
+            };
+
+            let expected_output_json = json!({
+                "type": "Feature",
+                "geometry": null,
+                "properties": {
+                    "name": "burbs"
+                }
+            });
+
+            let actual_output = to_feature_string(&my_feature).unwrap();
+            let actual_output_json = JsonValue::from_str(&actual_output).unwrap();
+            assert_eq!(actual_output_json, expected_output_json);
+        }
+
+        #[test]
+        fn without_geom_field() {
+            #[derive(Serialize)]
+            struct MyStructWithoutGeom {
+                // geometry: Option<crate::Geometry>,
+                name: String,
+            }
+            let my_feature = {
+                let name = "burbs".to_string();
+                MyStructWithoutGeom { name }
+            };
+
+            let actual_output = to_feature_string(&my_feature).unwrap_err();
+            let error_message = actual_output.to_string();
+
+            // BRITTLE: we'll need to update this test if the error message changes.
+            assert!(error_message.contains("missing"));
+            assert!(error_message.contains("geometry"));
+        }
+
+        #[test]
+        fn serializes_whatever_geometry() {
+            #[derive(Serialize)]
+            struct MyStructWithWeirdGeom {
+                // This isn't a valid geometry representation, but we don't really have a way to "validate" it
+                // so serde will serialize whatever. This test exists just to document current behavior
+                // not that it's exactly desirable.
+                geometry: Vec<u32>,
+                name: String,
+            }
+            let my_feature = {
+                let geometry = vec![1, 2, 3];
+                let name = "burbs".to_string();
+                MyStructWithWeirdGeom { geometry, name }
+            };
+
+            let expected_output_json = json!({
+                "type": "Feature",
+                "geometry": [1, 2, 3],
+                "properties": {
+                    "name": "burbs"
+                }
+            });
+
+            let actual_output = to_feature_string(&my_feature).unwrap();
+            let actual_output_json = JsonValue::from_str(&actual_output).unwrap();
+            assert_eq!(actual_output_json, expected_output_json);
+        }
+    }
+
+    #[cfg(feature = "geo-types")]
+    mod geo_types_tests {
+        use super::*;
+        use crate::de::tests::feature_collection;
+
+        #[test]
+        fn geometry_field_without_helper() {
+            #[derive(Serialize)]
+            struct MyStruct {
+                // If we forget the "serialize_with" helper, bad things happen.
+                // This test documents that:
+                //
+                // #[serde(serialize_with = "serialize_geometry")]
+                geometry: geo_types::Point<f64>,
+                name: String,
+                age: u64,
+            }
+
+            let my_struct = MyStruct {
+                geometry: geo_types::point!(x: 125.6, y: 10.1),
+                name: "Dinagat Islands".to_string(),
+                age: 123,
+            };
+
+            let expected_invalid_output = json!({
+              "type": "Feature",
+              // This isn't a valid geojson-Geometry. This behavior probably isn't desirable, but this
+              // test documents the current behavior of what happens if the users forgets "serialize_geometry"
+              "geometry": { "x": 125.6, "y": 10.1 },
+              "properties": {
+                "name": "Dinagat Islands",
+                "age": 123
+              }
+            });
+
+            // Order might vary, so re-parse to do a semantic comparison of the content.
+            let output_string = to_feature_string(&my_struct).expect("valid serialization");
+            let actual_output = JsonValue::from_str(&output_string).unwrap();
+
+            assert_eq!(actual_output, expected_invalid_output);
+        }
+
+        #[test]
+        fn geometry_field() {
+            #[derive(Serialize)]
+            struct MyStruct {
+                #[serde(serialize_with = "serialize_geometry")]
+                geometry: geo_types::Point<f64>,
+                name: String,
+                age: u64,
+            }
+
+            let my_struct = MyStruct {
+                geometry: geo_types::point!(x: 125.6, y: 10.1),
+                name: "Dinagat Islands".to_string(),
+                age: 123,
+            };
+
+            let expected_output = json!({
+              "type": "Feature",
+              "geometry": {
+                "type": "Point",
+                "coordinates": [125.6, 10.1]
+              },
+              "properties": {
+                "name": "Dinagat Islands",
+                "age": 123
+              }
+            });
+
+            // Order might vary, so re-parse to do a semantic comparison of the content.
+            let output_string = to_feature_string(&my_struct).expect("valid serialization");
+            let actual_output = JsonValue::from_str(&output_string).unwrap();
+
+            assert_eq!(actual_output, expected_output);
+        }
+
+        #[test]
+        fn serialize_feature_collection() {
+            #[derive(Serialize)]
+            struct MyStruct {
+                #[serde(serialize_with = "serialize_geometry")]
+                geometry: geo_types::Point<f64>,
+                name: String,
+                age: u64,
+            }
+
+            let my_structs = vec![
+                MyStruct {
+                    geometry: geo_types::point!(x: 125.6, y: 10.1),
+                    name: "Dinagat Islands".to_string(),
+                    age: 123,
+                },
+                MyStruct {
+                    geometry: geo_types::point!(x: 2.3, y: 4.5),
+                    name: "Neverland".to_string(),
+                    age: 456,
+                },
+            ];
+
+            let output_string =
+                to_feature_collection_string(&my_structs).expect("valid serialization");
+
+            // Order might vary, so re-parse to do a semantic comparison of the content.
+            let expected_output = feature_collection();
+            let actual_output = JsonValue::from_str(&output_string).unwrap();
+
+            assert_eq!(actual_output, expected_output);
+        }
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -64,7 +64,7 @@ fn expect_owned_array(value: JsonValue) -> Result<Vec<JsonValue>> {
     }
 }
 
-fn expect_owned_object(value: JsonValue) -> Result<JsonObject> {
+pub(crate) fn expect_owned_object(value: JsonValue) -> Result<JsonObject> {
     match value {
         JsonValue::Object(o) => Ok(o),
         _ => Err(Error::ExpectedObjectValue(value)),


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This is an attempt to improve the ergonomics of parsing GeoJson using serde (FIXES https://github.com/georust/geojson/issues/184) . 

~~This PR is a draft because there are a lot of error paths related to invalid parsing that I'd like to add tests for, but I first wanted to check in on overall direction of the API. What do people think?~~ I think this is ready for review!

# Examples

Given some geojson like this:
```rust
let feature_collection_string = r#"{
    "type": "FeatureCollection",
    "features": [
        {
           "type": "Feature",
           "geometry": {
             "type": "Point",
             "coordinates": [125.6, 10.1]
           },
           "properties": {
             "name": "Dinagat Islands",
             "age": 123
           }
        },
        {
           "type": "Feature",
           "geometry": {
             "type": "Point",
             "coordinates": [2.3, 4.5]
           },
           "properties": {
             "name": "Neverland",
             "age": 456
           }
         }
   ]
}"#
.as_bytes();

let io_reader = std::io::BufReader::new(feature_collection_string);
```

## Before 

### Deserialization

You used to parse it like this:
```
use geojson:: FeatureIterator;
let feature_reader = FeatureIterator::new(io_reader);
for feature in feature_reader.features() {
    let feature = feature.expect("valid geojson feature");

    let name = feature.property("name").unwrap().as_str().unwrap();
    let age = feature.property("age").unwrap().as_u64().unwrap();
    let geometry = feature.geometry.value.try_into().unwrap();

    if name == "Dinagat Islands" {
        assert_eq!(123, age);
        assert_matches!(geometry, geo_types::Point::new(125.6, 10.1).into());
    } else if name == "Neverland" {
        assert_eq!(456, age);
        assert_matches!(geometry, geo_types::Point::new(2.3, 4.5).into());
    } else {
        panic!("unexpected name: {}", name);
    }
}
```

### Serialization

Then, to write it back to geojson, you'd have to either do all your processing strictly with the geojson types, or somehow convert your entities from and back to one of the GeoJson entities:

Something like:
```
// The implementation of this method is potentially a little messy / boilerplatey
let feature_collection: geojson::FeatureCollection = some_custom_method_to_convert_to_geojson(&my_structs);

// This part is easy enough though
serde_json::to_string(&geojson);
```

## After

But now you also have the option of parsing it into your own declarative struct using serde like this:

### Declaration
```
use geojson::{ser::serialize_geometry, de::deserialize_geometry};
use serde::{Serialize, Deserialize};

#[derive(Serialize, Deserialize)]
struct MyStruct {
    // You can parse directly to geo_types via these helpers, otherwise this field will need to be a `geojson::Geometry`
    #[serde(serialize_with = "serialize_geometry", deserialize_with = "deserialize_geometry")]
    geometry: geo_types::Point<f64>,
    name: String,
    age: u64,
}
```

### Deserialization
```
for feature in geojson::de::deserialize_feature_collection::<MyStruct>(io_reader).unwrap() {
    let my_struct = feature.expect("valid geojson feature");

    if my_struct.name == "Dinagat Islands" {
        assert_eq!(my_struct.age, 123);
        assert_eq!(my_struct.geometry, geo_types::Point::new(125.6, 10.1));
    } else if my_struct.name == "Neverland" {
        assert_eq!(my_struct.age, 456);
        assert_eq!(my_struct.geometry, geo_types::Point::new(2.3, 4.5));
    } else {
        panic!("unexpected name: {}", my_struct.name);
    }
}
```

### Serialization

```
let my_structs: Vec<MyStruct> = get_my_structs();
geojson::ser::to_feature_collection_writer(writer, &my_structs).expect("valid serialization");
```


## Caveats

### Performance

Performance currently isn't great. There's a couple of things which seem ridiculous in the code that I've marked with `PERF:` that I don't have an immediate solution for. This is my first time really diving into the internals of serde and it's kind of a lot! My hope is that performance improvements would be possible with no or little changes to the API.


Some specific numbers (from some admittedly crude benchmarks):

**Old Deserialization:**
```
FeatureReader::features (countries.geojson)                                                                                                                                  
                        time:   [5.8497 ms 5.8607 ms 5.8728 ms]                                                                                                              
```

**New Deserialization:**
```                                                                                                                                                                             
FeatureReader::deserialize (countries.geojson)                                                                                                                               
                        time:   [7.1702 ms 7.1865 ms 7.2035 ms]                                                                                                              
```

**Old serialization:**
```
serialize geojson::FeatureCollection struct (countries.geojson)                                                                             
                        time:   [3.1471 ms 3.1552 ms 3.1637 ms]
```

**New serialization:**
```
serialize custom struct (countries.geojson)                                                                             
                        time:   [3.8076 ms 3.8144 ms 3.8219 ms]
```

So the new "ergonomic" serialization/deserialization takes about 1.2x the time as the old way. Though it's actually probably a bit better than that because with the new form you have all your data ready to use. With the old way, you still need to go through this dance before you can start your analysis:
```
let name = feature.property("name").unwrap().as_str().unwrap();
let age = feature.property("age").unwrap().as_u64().unwrap();
let geometry = feature.geometry.value.try_into().unwrap();
```

Anyway, I think this kind of speed difference is well worth the improved usability for my use cases.

### Foreign Members

This doesn't support anything besides `geometry` and `properties` - e.g. foreign members are dropped. I'm hopeful that this is useful even with that limitation, but if not, maybe we can think of a way to accommodate most people's needs.