### PR TITLE
Flexible field ordering for FeatureIterator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED
 
+* Fix: FeatureIterator errors when reading "features" field before "type" field.
+  * <https://github.com/georust/geojson/pull/200>
 * Added IntoIter implementation for FeatureCollection.
   * <https://github.com/georust/geojson/pull/196>
 * Add `geojson::Result<T>`

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -1,15 +1,41 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use geojson;
+use geojson::GeoJson;
+use std::io::BufReader;
 
-fn parse_benchmark(c: &mut Criterion) {
+fn parse_feature_collection_benchmark(c: &mut Criterion) {
     c.bench_function("parse (countries.geojson)", |b| {
         let geojson_str = include_str!("../tests/fixtures/countries.geojson");
 
         b.iter(|| {
-            let _ = black_box(geojson_str.parse::<geojson::GeoJson>());
-        });
+            let _ = black_box({
+                match geojson_str.parse::<geojson::GeoJson>() {
+                    Ok(GeoJson::FeatureCollection(fc)) => {
+                        assert_eq!(fc.features.len(), 180);
+                    }
+                    _ => panic!("unexpected result"),
+                }
+            });
+        })
     });
 
+    c.bench_function("FeatureIter (countries.geojson)", |b| {
+        let geojson_str = include_str!("../tests/fixtures/countries.geojson");
+
+        b.iter(|| {
+            let feature_iter =
+                geojson::FeatureIterator::new(BufReader::new(geojson_str.as_bytes()));
+            let _ = black_box({
+                let mut count = 0;
+                for _ in feature_iter {
+                    count += 1;
+                }
+                assert_eq!(count, 184);
+            });
+        });
+    });
+}
+
+fn parse_geometry_collection_benchmark(c: &mut Criterion) {
     c.bench_function("parse (geometry_collection.geojson)", |b| {
         let geojson_str = include_str!("../tests/fixtures/geometry_collection.geojson");
 
@@ -19,5 +45,9 @@ fn parse_benchmark(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, parse_benchmark);
+criterion_group!(
+    benches,
+    parse_feature_collection_benchmark,
+    parse_geometry_collection_benchmark
+);
 criterion_main!(benches);

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -1,14 +1,12 @@
-#![feature(test)]
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use geojson;
-extern crate test;
 
 fn parse_benchmark(c: &mut Criterion) {
     c.bench_function("parse (countries.geojson)", |b| {
         let geojson_str = include_str!("../tests/fixtures/countries.geojson");
 
         b.iter(|| {
-            let _ = test::black_box(geojson_str.parse::<geojson::GeoJson>());
+            let _ = black_box(geojson_str.parse::<geojson::GeoJson>());
         });
     });
 
@@ -16,7 +14,7 @@ fn parse_benchmark(c: &mut Criterion) {
         let geojson_str = include_str!("../tests/fixtures/geometry_collection.geojson");
 
         b.iter(|| {
-            let _ = test::black_box(geojson_str.parse::<geojson::GeoJson>());
+            let _ = black_box(geojson_str.parse::<geojson::GeoJson>());
         });
     });
 }

--- a/benches/to_geo_types.rs
+++ b/benches/to_geo_types.rs
@@ -1,19 +1,16 @@
-#![feature(test)]
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-extern crate test;
-
-fn parse_benchmark(c: &mut Criterion) {
+fn benchmark_group(c: &mut Criterion) {
     let geojson_str = include_str!("../tests/fixtures/countries.geojson");
     let geojson = geojson_str.parse::<geojson::GeoJson>().unwrap();
 
     c.bench_function("quick_collection", move |b| {
         b.iter(|| {
             let _: Result<geo_types::GeometryCollection<f64>, _> =
-                test::black_box(geojson::quick_collection(&geojson));
+                black_box(geojson::quick_collection(&geojson));
         });
     });
 }
 
-criterion_group!(benches, parse_benchmark);
+criterion_group!(benches, benchmark_group);
 criterion_main!(benches);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,6 +16,8 @@ pub enum Error {
     /// This was previously `GeoJsonUnknownType`, but has been split for clarity
     #[error("Expected a Feature, FeatureCollection, or Geometry, but got an empty type")]
     EmptyType,
+    #[error("IO Error: {0}")]
+    Io(std::io::Error),
     /// This was previously `GeoJsonUnknownType`, but has been split for clarity
     #[error("Expected a Feature mapping, but got a `{0}`")]
     NotAFeature(String),
@@ -56,5 +58,11 @@ pub type Result<T> = std::result::Result<T, Error>;
 impl From<serde_json::Error> for Error {
     fn from(error: serde_json::Error) -> Self {
         Self::MalformedJson(error)
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(error)
     }
 }

--- a/src/feature_iterator.rs
+++ b/src/feature_iterator.rs
@@ -12,11 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate serde;
-extern crate serde_derive;
-extern crate serde_json;
-
-use crate::Feature;
+use crate::{Feature, Result};
 
 use std::io;
 use std::marker::PhantomData;
@@ -32,19 +28,22 @@ use std::marker::PhantomData;
 /// [GeoJSON Format Specification § 3.3](https://datatracker.ietf.org/doc/html/rfc7946#section-3.3)
 pub struct FeatureIterator<R> {
     reader: R,
-    skip: Option<u8>,
-    skip_preamble: bool,
-    skip_appendix: bool,
+    state: State,
     marker: PhantomData<Feature>,
+}
+
+#[derive(Debug, Copy, Clone)]
+enum State {
+    BeforeFeatures,
+    DuringFeatures,
+    AfterFeatures,
 }
 
 impl<R> FeatureIterator<R> {
     pub fn new(reader: R) -> Self {
         FeatureIterator {
-            reader: reader,
-            skip: Some(b'['),
-            skip_preamble: true,
-            skip_appendix: false,
+            reader,
+            state: State::BeforeFeatures,
             marker: PhantomData,
         }
     }
@@ -54,24 +53,40 @@ impl<R> FeatureIterator<R>
 where
     R: io::Read,
 {
-    fn skip_past_byte(&mut self, byte: u8) -> io::Result<bool> {
-        let mut one_byte = [0];
+    fn seek_to_next_feature(&mut self) -> Result<bool> {
+        let mut next_bytes = [0];
         loop {
-            if self.reader.read_exact(&mut one_byte).is_err() {
-                return Ok(false);
+            self.reader.read_exact(&mut next_bytes)?;
+            let next_byte = next_bytes[0] as char;
+            if next_byte.is_whitespace() {
+                continue;
             }
-            if one_byte[0] == byte {
-                return Ok(true);
-            }
-            if one_byte[0] == b']' {
-                self.skip_appendix = true;
-            }
-            if !self.skip_preamble && !self.skip_appendix && !(one_byte[0] as char).is_whitespace()
-            {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    format!("byte {}", one_byte[0]),
-                ));
+
+            match (self.state, next_byte) {
+                (State::BeforeFeatures, '[') => {
+                    self.state = State::DuringFeatures;
+                    return Ok(true);
+                }
+                (State::BeforeFeatures, _) => {
+                    continue;
+                }
+                (State::DuringFeatures, ',') => {
+                    return Ok(true);
+                }
+                (State::DuringFeatures, ']') => {
+                    self.state = State::AfterFeatures;
+                    return Ok(false);
+                }
+                (State::AfterFeatures, _) => {
+                    unreachable!("should not seek if we've already finished processing features")
+                }
+                _ => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!("next byte: {}", next_byte),
+                    )
+                    .into());
+                }
             }
         }
     }
@@ -81,27 +96,20 @@ impl<R> Iterator for FeatureIterator<R>
 where
     R: io::Read,
 {
-    type Item = io::Result<Feature>;
+    type Item = Result<Feature>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(skip) = self.skip {
-            match self.skip_past_byte(skip) {
-                Ok(true) => {}
-                Ok(false) => {
-                    return None;
-                }
-                Err(err) => {
-                    return Some(Err(err));
-                }
+        match self.seek_to_next_feature() {
+            Ok(true) => {}
+            Ok(false) => return None,
+            Err(err) => {
+                return Some(Err(err));
             }
-            self.skip = None;
         }
+
         let de = serde_json::Deserializer::from_reader(&mut self.reader);
         match de.into_iter().next() {
-            Some(Ok(v)) => {
-                self.skip = Some(b',');
-                Some(Ok(v))
-            }
+            Some(Ok(v)) => Some(Ok(v)),
             Some(Err(err)) => Some(Err(err.into())),
             None => None,
         }
@@ -202,5 +210,78 @@ mod tests {
             fi.next().unwrap().unwrap().geometry.unwrap()
         );
         assert!(fi.next().is_none());
+    }
+
+    mod field_ordering {
+        use super::*;
+
+        #[test]
+        fn type_field_before_features_field() {
+            use crate::Feature;
+
+            let type_first = r#"
+              {
+                type: "FeatureCollection",
+                features: [
+                  {
+                    "type": "Feature",
+                    "geometry": {
+                      "type": "Point",
+                      "coordinates": [1.1, 1.2]
+                    },
+                    "properties": { }
+                  },
+                  {
+                    "type": "Feature",
+                    "geometry": {
+                      "type": "Point",
+                      "coordinates": [2.1, 2.2]
+                    },
+                    "properties": { }
+                  }
+                ]
+              }
+            "#;
+            let features: Vec<Feature> =
+                FeatureIterator::new(BufReader::new(type_first.as_bytes()))
+                    .map(Result::unwrap)
+                    .collect();
+            assert_eq!(features.len(), 2);
+        }
+
+        #[test]
+        fn features_field_before_type_field() {
+            use crate::Feature;
+            env_logger::init();
+
+            let type_first = r#"
+              {
+                features: [
+                  {
+                    "type": "Feature",
+                    "geometry": {
+                      "type": "Point",
+                      "coordinates": [1.1, 1.2]
+                    },
+                    "properties": {}
+                  },
+                  {
+                    "type": "Feature",
+                    "geometry": {
+                      "type": "Point",
+                      "coordinates": [2.1, 2.2]
+                    },
+                    "properties": { }
+                  }
+                ],
+                type: "FeatureCollection"
+              }
+            "#;
+            let features: Vec<Feature> =
+                FeatureIterator::new(BufReader::new(type_first.as_bytes()))
+                    .map(Result::unwrap)
+                    .collect();
+            assert_eq!(features.len(), 2);
+        }
     }
 }

--- a/src/feature_iterator.rs
+++ b/src/feature_iterator.rs
@@ -214,11 +214,10 @@ mod tests {
 
     mod field_ordering {
         use super::*;
+        use crate::Feature;
 
         #[test]
         fn type_field_before_features_field() {
-            use crate::Feature;
-
             let type_first = r#"
               {
                 type: "FeatureCollection",
@@ -251,9 +250,6 @@ mod tests {
 
         #[test]
         fn features_field_before_type_field() {
-            use crate::Feature;
-            env_logger::init();
-
             let type_first = r#"
               {
                 features: [


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

I encountered this while working on #199, but I thought it made sense to extract the fix and address it separately.

Previously, `FeatureIterator` could read feature collections written like this:

`{ "type": "FeatureCollection", "features": [ ... ] }`

But would error when encountering a feature collection written like this:

`{"features": [ ... ],  "type": "FeatureCollection" }`

Now we handle both orderings.