### PR TITLE
stream reading features

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,9 +26,10 @@
     geojson::ser::to_feature_collection_string(&my_structs).unwrap();
     ```
   * PR: <https://github.com/georust/geojson/pull/199>
-* Added `geojson::{FeatureReader, FeatureWriter}` to stream the reading/writing of your custom struct to and from GeoJSON.
-  * PR: <https://github.com/georust/geojson/pull/199> 
+* Added `geojson::{FeatureReader, FeatureWriter}` to stream the reading/writing of your custom struct to and from GeoJSON, greatly reducing the memory required to process a FeatureCollection.
+  * PR: <https://github.com/georust/geojson/pull/199>
   * PR: <https://github.com/georust/geojson/pull/205>
+  * PR: <https://github.com/georust/geojson/pull/206>
 * Added IntoIter implementation for FeatureCollection.
   * <https://github.com/georust/geojson/pull/196>
 * Added `geojson::Result<T>`.


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This greatly reduces the peak memory usage needed to parse a GeoJSON FeatureCollection by utilizing the FeatureIterator's trick of seeking to the `"features": [` array without actually parsing the FeatureCollection. Note there are [some robustness issues](https://github.com/georust/geojson/issues/207) with this approach, some of which can be improved, but overall I think it's worth the trade-off.

There is a small (0-1%) CPU regression in our deserialization bench due to this change, but the peak memory profile of the `stream_reader_writer` examples decreased 90% - from 2.22MiB to 237Kib.

Before:
<img width="1624" alt="Screen Shot 2022-09-02 at 2 42 04 PM" src="https://user-images.githubusercontent.com/217057/188239657-ade76677-f3e2-4750-b71d-bed0effbe215.png">

After:
<img width="1624" alt="Screen Shot 2022-09-02 at 2 40 29 PM" src="https://user-images.githubusercontent.com/217057/188239645-5274e0ff-71b2-4da6-8ac9-1f72d288c2bb.png">

Notice that overall memory allocations stayed the same (see https://github.com/georust/geojson/issues/88#issuecomment-1228961870), but the peak usage is much lower since we never hold the entire data structure in memory at once.
