### PR TITLE
Added support for okapi that can be configured as feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,16 @@ edition = "2018"
 
 [features]
 default = ["geo-types"]
+okapi_support = ["okapi"]
 
 [dependencies]
+okapi = {version="0.7.0-rc.1", optional = true}
 serde = { version="~1.0", features = ["derive"] }
 serde_json = "~1.0"
 geo-types = { version = "0.7", features = ["serde"], optional = true }
 thiserror = "1.0.20"
 log = "0.4.17"
+
 
 [dev-dependencies]
 num-traits = "0.2"

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -20,6 +20,10 @@ use crate::{util, Feature, Geometry, Value};
 use crate::{JsonObject, JsonValue};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::json;
+#[cfg(feature = "okapi_support")]
+use okapi::schemars;
+#[cfg(feature = "okapi_support")]
+use okapi::schemars::JsonSchema;
 
 impl From<Geometry> for Feature {
     fn from(geom: Geometry) -> Feature {
@@ -203,6 +207,7 @@ impl<'de> Deserialize<'de> for Feature {
 ///
 /// [GeoJSON Format Specification § 3.2](https://tools.ietf.org/html/rfc7946#section-3.2)
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "okapi_support", derive(JsonSchema))]
 pub enum Id {
     String(String),
     Number(serde_json::Number),

--- a/src/feature_collection.rs
+++ b/src/feature_collection.rs
@@ -21,6 +21,10 @@ use crate::{util, Bbox, Feature};
 use crate::{JsonObject, JsonValue};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::json;
+#[cfg(feature = "okapi_support")]
+use okapi::schemars;
+#[cfg(feature = "okapi_support")]
+use okapi::schemars::JsonSchema;
 
 /// Feature Collection Objects
 ///
@@ -61,7 +65,8 @@ use serde_json::json;
 ///     .collect();
 /// assert_eq!(fc.features.len(), 10);
 /// ```
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "okapi_support", derive(JsonSchema))]
 pub struct FeatureCollection {
     /// Bounding Box
     ///

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -19,6 +19,10 @@ use crate::errors::{Error, Result};
 use crate::{util, Bbox, LineStringType, PointType, PolygonType};
 use crate::{JsonObject, JsonValue};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+#[cfg(feature = "okapi_support")]
+use okapi::schemars;
+#[cfg(feature = "okapi_support")]
+use okapi::schemars::JsonSchema;
 
 /// The underlying value for a `Geometry`.
 ///
@@ -46,6 +50,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// # test()
 /// ```
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "okapi", derive(JsonSchema))]
 pub enum Value {
     /// Point
     ///
@@ -243,6 +248,7 @@ impl Serialize for Value {
 /// let geom: geo_types::Geometry<f64> = geometry.try_into().unwrap();
 /// ```
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "okapi_support", derive(JsonSchema))]
 pub struct Geometry {
     /// Bounding Box
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -474,10 +474,16 @@ pub use feature_writer::FeatureWriter;
 #[cfg(feature = "geo-types")]
 pub use conversion::quick_collection;
 
+#[cfg(feature = "okapi_support")]
+use okapi::schemars;
+#[cfg(feature = "okapi_support")]
+use okapi::schemars::JsonSchema;
+
 /// Feature Objects
 ///
 /// [GeoJSON Format Specification § 3.2](https://tools.ietf.org/html/rfc7946#section-3.2)
 #[derive(Clone, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "okapi_support", derive(JsonSchema))]
 pub struct Feature {
     /// Bounding Box
     ///


### PR DESCRIPTION
- Added feature 'okapi_support'
- If feature is enabled
  - dependency to okapi
  - geo-json types have a JsonSchema derive

Okapi allows automated OpenAPI (AKA Swagger) document generation.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

