### PR TITLE
deprecate quick_collection, simplify docs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@
 * Changed `Serialize` impls to avoid creating intermediate `JsonObject`s.
 * Better CI: lint, all features
 * Implement `Default` on `FeatureCollection`.
+* Added `GeometryCollection::try_from(&GeoJson)` and deprecated
+  `quick_collection` for conventional naming and simpler docs.
+  * <https://github.com/georust/geojson/pulls/214>
 
 ## 0.24.1
 
@@ -17,7 +20,7 @@
 
 ## 0.24.0
 
-* Added `geojson::{ser, de}` helpers to convert your custom struct to and from GeoJSON. 
+* Added `geojson::{ser, de}` helpers to convert your custom struct to and from GeoJSON.
   * For external geometry types like geo-types, use the `serialize_geometry`/`deserialize_geometry` helpers.
   * Example:
     ```

--- a/benches/to_geo_types.rs
+++ b/benches/to_geo_types.rs
@@ -1,15 +1,13 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::convert::TryFrom;
 
 fn benchmark_group(c: &mut Criterion) {
     let geojson_str = include_str!("../tests/fixtures/countries.geojson");
     let geojson = geojson_str.parse::<geojson::GeoJson>().unwrap();
 
     #[cfg(feature = "geo-types")]
-    c.bench_function("quick_collection", move |b| {
-        b.iter(|| {
-            let _: Result<geo_types::GeometryCollection<f64>, _> =
-                black_box(geojson::quick_collection(&geojson));
-        });
+    c.bench_function("Convert to geo-types", move |b| {
+        b.iter(|| black_box(geo_types::GeometryCollection::<f64>::try_from(&geojson).unwrap()));
     });
 }
 

--- a/src/conversion/from_geo_types.rs
+++ b/src/conversion/from_geo_types.rs
@@ -356,9 +356,9 @@ mod tests {
 
     #[test]
     fn geo_triangle_conversion_test() {
-        let c1 = Coord { x: 0., y: 0. };
-        let c2 = Coord { x: 10., y: 20. };
-        let c3 = Coord { x: 20., y: -10. };
+        let c1: Coord<f64> = Coord { x: 0., y: 0. };
+        let c2: Coord<f64> = Coord { x: 10., y: 20. };
+        let c3: Coord<f64> = Coord { x: 20., y: -10. };
 
         let triangle = Triangle(c1, c2, c3);
 
@@ -366,14 +366,14 @@ mod tests {
 
         // Geo-types Polygon construction introduces an extra vertex: let's check it!
         if let Value::Polygon(c) = geojson_polygon {
-            assert_almost_eq!(c1.x as f64, c[0][0][0], 1e-6);
-            assert_almost_eq!(c1.y as f64, c[0][0][1], 1e-6);
-            assert_almost_eq!(c2.x as f64, c[0][1][0], 1e-6);
-            assert_almost_eq!(c2.y as f64, c[0][1][1], 1e-6);
-            assert_almost_eq!(c3.x as f64, c[0][2][0], 1e-6);
-            assert_almost_eq!(c3.y as f64, c[0][2][1], 1e-6);
-            assert_almost_eq!(c1.x as f64, c[0][3][0], 1e-6);
-            assert_almost_eq!(c1.y as f64, c[0][3][1], 1e-6);
+            assert_almost_eq!(c1.x, c[0][0][0], 1e-6);
+            assert_almost_eq!(c1.y, c[0][0][1], 1e-6);
+            assert_almost_eq!(c2.x, c[0][1][0], 1e-6);
+            assert_almost_eq!(c2.y, c[0][1][1], 1e-6);
+            assert_almost_eq!(c3.x, c[0][2][0], 1e-6);
+            assert_almost_eq!(c3.y, c[0][2][1], 1e-6);
+            assert_almost_eq!(c1.x, c[0][3][0], 1e-6);
+            assert_almost_eq!(c1.y, c[0][3][1], 1e-6);
         } else {
             panic!("Not valid geometry {:?}", geojson_polygon);
         }
@@ -381,8 +381,8 @@ mod tests {
 
     #[test]
     fn geo_rect_conversion_test() {
-        let c1 = Coord { x: 0., y: 0. };
-        let c2 = Coord { x: 10., y: 20. };
+        let c1: Coord<f64> = Coord { x: 0., y: 0. };
+        let c2: Coord<f64> = Coord { x: 10., y: 20. };
 
         let rect = Rect::new(c1, c2);
 
@@ -390,16 +390,16 @@ mod tests {
 
         // Geo-types Polygon construction introduces an extra vertex: let's check it!
         if let Value::Polygon(c) = geojson_polygon {
-            assert_almost_eq!(c1.x as f64, c[0][0][0], 1e-6);
-            assert_almost_eq!(c1.y as f64, c[0][0][1], 1e-6);
-            assert_almost_eq!(c1.x as f64, c[0][1][0], 1e-6);
-            assert_almost_eq!(c2.y as f64, c[0][1][1], 1e-6);
-            assert_almost_eq!(c2.x as f64, c[0][2][0], 1e-6);
-            assert_almost_eq!(c2.y as f64, c[0][2][1], 1e-6);
-            assert_almost_eq!(c2.x as f64, c[0][3][0], 1e-6);
-            assert_almost_eq!(c1.y as f64, c[0][3][1], 1e-6);
-            assert_almost_eq!(c1.x as f64, c[0][4][0], 1e-6);
-            assert_almost_eq!(c1.y as f64, c[0][4][1], 1e-6);
+            assert_almost_eq!(c1.x, c[0][0][0], 1e-6);
+            assert_almost_eq!(c1.y, c[0][0][1], 1e-6);
+            assert_almost_eq!(c1.x, c[0][1][0], 1e-6);
+            assert_almost_eq!(c2.y, c[0][1][1], 1e-6);
+            assert_almost_eq!(c2.x, c[0][2][0], 1e-6);
+            assert_almost_eq!(c2.y, c[0][2][1], 1e-6);
+            assert_almost_eq!(c2.x, c[0][3][0], 1e-6);
+            assert_almost_eq!(c1.y, c[0][3][1], 1e-6);
+            assert_almost_eq!(c1.x, c[0][4][0], 1e-6);
+            assert_almost_eq!(c1.y, c[0][4][1], 1e-6);
         } else {
             panic!("Not valid geometry {:?}", geojson_polygon);
         }

--- a/src/conversion/mod.rs
+++ b/src/conversion/mod.rs
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use geo_types::{self, CoordFloat, GeometryCollection};
+use geo_types::CoordFloat;
 
 use crate::geojson::GeoJson;
-use crate::geojson::GeoJson::{Feature, FeatureCollection, Geometry};
 
 use crate::Result;
-use std::convert::TryInto;
+use std::convert::TryFrom;
 
 #[cfg(test)]
 macro_rules! assert_almost_eq {
@@ -79,32 +78,6 @@ macro_rules! try_from_owned_value {
 pub(crate) mod from_geo_types;
 pub(crate) mod to_geo_types;
 
-// Process top-level `GeoJSON` items, returning a geo_types::GeometryCollection or an Error
-fn process_geojson<T>(gj: &GeoJson) -> Result<geo_types::GeometryCollection<T>>
-where
-    T: CoordFloat,
-{
-    match gj {
-        FeatureCollection(collection) => Ok(GeometryCollection(
-            collection
-                .features
-                .iter()
-                // Only pass on non-empty geometries
-                .filter_map(|feature| feature.geometry.as_ref())
-                .map(|geometry| geometry.clone().try_into())
-                .collect::<Result<_>>()?,
-        )),
-        Feature(feature) => {
-            if let Some(geometry) = &feature.geometry {
-                Ok(GeometryCollection(vec![geometry.clone().try_into()?]))
-            } else {
-                Ok(GeometryCollection(vec![]))
-            }
-        }
-        Geometry(geometry) => Ok(GeometryCollection(vec![geometry.clone().try_into()?])),
-    }
-}
-
 /// A shortcut for producing `geo_types` [GeometryCollection](../geo_types/struct.GeometryCollection.html) objects
 /// from arbitrary valid GeoJSON input.
 ///
@@ -113,7 +86,8 @@ where
 /// # Example
 ///
 /// ```
-/// use geo_types::GeometryCollection;
+/// use geo_types::{Geometry, GeometryCollection, Point};
+/// #[allow(deprecated)]
 /// use geojson::{quick_collection, GeoJson};
 ///
 /// let geojson_str = r#"
@@ -125,10 +99,7 @@ where
 ///       "properties": {},
 ///       "geometry": {
 ///         "type": "Point",
-///         "coordinates": [
-///           -0.13583511114120483,
-///           51.5218870403801
-///         ]
+///         "coordinates": [-1.0, 2.0]
 ///       }
 ///     }
 ///   ]
@@ -136,12 +107,18 @@ where
 /// "#;
 /// let geojson = geojson_str.parse::<GeoJson>().unwrap();
 /// // Turn the GeoJSON string into a geo_types GeometryCollection
+/// #[allow(deprecated)]
 /// let mut collection: GeometryCollection<f64> = quick_collection(&geojson).unwrap();
+/// assert_eq!(collection[0], Geometry::Point(Point::new(-1.0, 2.0)))
 /// ```
+#[deprecated(
+    since = "0.24.1",
+    note = "use `geo_types::GeometryCollection::try_from(&geojson)` instead"
+)]
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 pub fn quick_collection<T>(gj: &GeoJson) -> Result<geo_types::GeometryCollection<T>>
 where
     T: CoordFloat,
 {
-    process_geojson(gj)
+    geo_types::GeometryCollection::try_from(gj)
 }

--- a/src/conversion/to_geo_types.rs
+++ b/src/conversion/to_geo_types.rs
@@ -356,7 +356,7 @@ where
     T: CoordFloat,
 {
     let exterior = polygon_type
-        .get(0)
+        .first()
         .map(|e| create_geo_line_string(e))
         .unwrap_or_else(|| create_geo_line_string(&vec![]));
 

--- a/src/conversion/to_geo_types.rs
+++ b/src/conversion/to_geo_types.rs
@@ -2,10 +2,8 @@ use geo_types::{self, CoordFloat};
 
 use crate::geometry;
 
-use crate::{
-    quick_collection, Feature, FeatureCollection, GeoJson, LineStringType, PointType, PolygonType,
-};
 use crate::{Error, Result};
+use crate::{Feature, FeatureCollection, GeoJson, LineStringType, PointType, PolygonType};
 use std::convert::{TryFrom, TryInto};
 
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
@@ -243,6 +241,40 @@ impl_try_from_geom_value![
     GeometryCollection
 ];
 
+impl<T: CoordFloat> TryFrom<&GeoJson> for geo_types::GeometryCollection<T> {
+    type Error = Error;
+
+    /// Process top-level `GeoJSON` items, returning a geo_types::GeometryCollection or an Error
+    fn try_from(gj: &GeoJson) -> Result<geo_types::GeometryCollection<T>>
+    where
+        T: CoordFloat,
+    {
+        match gj {
+            GeoJson::FeatureCollection(collection) => Ok(geo_types::GeometryCollection(
+                collection
+                    .features
+                    .iter()
+                    // Only pass on non-empty geometries
+                    .filter_map(|feature| feature.geometry.as_ref())
+                    .map(|geometry| geometry.clone().try_into())
+                    .collect::<Result<_>>()?,
+            )),
+            GeoJson::Feature(feature) => {
+                if let Some(geometry) = &feature.geometry {
+                    Ok(geo_types::GeometryCollection(vec![geometry
+                        .clone()
+                        .try_into()?]))
+                } else {
+                    Ok(geo_types::GeometryCollection(vec![]))
+                }
+            }
+            GeoJson::Geometry(geometry) => Ok(geo_types::GeometryCollection(vec![geometry
+                .clone()
+                .try_into()?])),
+        }
+    }
+}
+
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
 impl<T> TryFrom<FeatureCollection> for geo_types::Geometry<T>
 where
@@ -251,9 +283,9 @@ where
     type Error = Error;
 
     fn try_from(val: FeatureCollection) -> Result<geo_types::Geometry<T>> {
-        Ok(geo_types::Geometry::GeometryCollection(quick_collection(
-            &GeoJson::FeatureCollection(val),
-        )?))
+        Ok(geo_types::Geometry::GeometryCollection(
+            geo_types::GeometryCollection::try_from(&GeoJson::FeatureCollection(val))?,
+        ))
     }
 }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -471,7 +471,7 @@ pub(crate) mod tests {
 
         assert_eq!(records.len(), 2);
         let first_age = {
-            let props = records.get(0).unwrap().properties.as_ref().unwrap();
+            let props = records.first().unwrap().properties.as_ref().unwrap();
             props.get("age").unwrap().as_i64().unwrap()
         };
         assert_eq!(first_age, 123);

--- a/src/feature_collection.rs
+++ b/src/feature_collection.rs
@@ -227,7 +227,7 @@ impl FromIterator<Feature> for FeatureCollection {
                     }
                     Some(fbox) if curr_len == 0 => {
                         // First iteration: just copy values from fbox
-                        *curr_bbox = fbox.clone();
+                        curr_bbox.clone_from(fbox);
                     }
                     Some(fbox) if curr_len != fbox.len() => {
                         bbox = None;

--- a/src/feature_iterator.rs
+++ b/src/feature_iterator.rs
@@ -40,6 +40,7 @@ pub struct FeatureIterator<'de, R, D = Feature> {
     lifetime: PhantomData<&'de ()>,
 }
 
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Copy, Clone)]
 enum State {
     BeforeFeatures,

--- a/src/feature_writer.rs
+++ b/src/feature_writer.rs
@@ -187,11 +187,9 @@ impl<W: Write> FeatureWriter<W> {
         value: &T,
     ) -> Result<()> {
         match self.state {
-            State::Finished => {
-                return Err(Error::InvalidWriterState(
-                    "cannot write foreign member when writer has already finished",
-                ))
-            }
+            State::Finished => Err(Error::InvalidWriterState(
+                "cannot write foreign member when writer has already finished",
+            )),
             State::New => {
                 self.write_str(r#"{ "type": "FeatureCollection", "#)?;
                 write!(self.writer, "\"{key}\": ")?;
@@ -201,11 +199,9 @@ impl<W: Write> FeatureWriter<W> {
                 self.state = State::WritingForeignMembers;
                 Ok(())
             }
-            State::WritingFeatures => {
-                return Err(Error::InvalidWriterState(
-                    "must write foreign members before any features",
-                ))
-            }
+            State::WritingFeatures => Err(Error::InvalidWriterState(
+                "must write foreign members before any features",
+            )),
             State::WritingForeignMembers => {
                 write!(self.writer, "\"{key}\": ")?;
                 serde_json::to_writer(&mut self.writer, value)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,7 +245,7 @@
 //! [`geo-types`](../geo_types/index.html#structs) are a common geometry format used across many
 //! geospatial processing crates. The `geo-types` feature is enabled by default.
 //!
-//! ### From geo-types to geojson
+//! ### Convert `geo-types` to `geojson`
 //!
 //! [`From`] is implemented on the [`Value`] enum variants to allow conversion _from_ [`geo-types`
 //! Geometries](../geo_types/index.html#structs).
@@ -295,67 +295,21 @@
 //! # }
 //! ```
 //!
-//! ### From geojson to geo-types
+//! ### Convert `geojson` to `geo-types`
 //!
-//! The optional `geo-types` feature implements the [`TryFrom`](../std/convert/trait.TryFrom.html)
-//! trait, providing **fallible** conversions _to_ [geo-types Geometries](../geo_types/index.html#structs)
-//! from [GeoJSON `Value`](enum.Value.html) enums.
+//! The `geo-types` feature implements the [`TryFrom`](../std/convert/trait.TryFrom.html) trait,
+//! providing **fallible** conversions _to_ [geo-types Geometries](../geo_types/index.html#structs)
+//! from [`GeoJson`], [`Value`], or [`Geometry`] types.
 //!
-//! **In most cases it is assumed that you want to convert GeoJSON into `geo` primitive types in
-//! order to process, transform, or measure them:**
-//! - `match` on `geojson`, iterating over its `features` field, yielding `Option<Feature>`.
-//! - process each `Feature`, accessing its `Value` field, yielding `Option<Value>`.
-//!
-//! Each [`Value`](enum.Value.html) represents a primitive type, such as a coordinate, point,
-//! linestring, polygon, or its multi- equivalent, **and each of these has an equivalent `geo`
-//! primitive type**, which you can convert to using the `std::convert::TryFrom` trait.
-//!
-//! #### GeoJSON to geo_types::GeometryCollection
-//!
-//! Unifying these features, the [`quick_collection`](fn.quick_collection.html) function accepts a [`GeoJson`](enum.GeoJson.html) enum
-//! and processes it, producing a [`GeometryCollection`](../geo_types/struct.GeometryCollection.html)
-//! whose members can be transformed, measured, rotated, etc using the algorithms and functions in
-//! the [`geo`](https://docs.rs/geo) crate:
+//! #### Convert `geojson` to `geo_types::Geometry<f64>`
 //!
 //! ```
 //! # #[cfg(feature = "geo-types")]
 //! # {
-//! // requires enabling the `geo-types` feature
-//! use geo_types::GeometryCollection;
-//! use geojson::{quick_collection, GeoJson};
-//! let geojson_str = r#"
-//! {
-//!   "type": "FeatureCollection",
-//!   "features": [
-//!     {
-//!       "type": "Feature",
-//!       "properties": {},
-//!       "geometry": {
-//!         "type": "Point",
-//!         "coordinates": [
-//!           -0.13583511114120483,
-//!           51.5218870403801
-//!         ]
-//!       }
-//!     }
-//!   ]
-//! }
-//! "#;
-//! let geojson = geojson_str.parse::<GeoJson>().unwrap();
-//! // Turn the GeoJSON string into a geo_types GeometryCollection
-//! let mut collection: GeometryCollection<f64> = quick_collection(&geojson).unwrap();
-//! # }
-//! ```
-//!
-//! #### Convert `GeoJson` to `geo_types::Geometry<f64>`
-//!
-//! ```
-//! # #[cfg(feature = "geo-types")]
-//! # {
-//! // requires enabling the `geo-types` feature
+//! // This example requires the `geo-types` feature
 //! use geo_types::Geometry;
 //! use geojson::GeoJson;
-//! use std::convert::TryInto;
+//! use std::convert::TryFrom;
 //! use std::str::FromStr;
 //!
 //! let geojson_str = r#"
@@ -373,7 +327,7 @@
 //! "#;
 //! let geojson = GeoJson::from_str(geojson_str).unwrap();
 //! // Turn the GeoJSON string into a geo_types Geometry
-//! let geom: geo_types::Geometry<f64> = geojson.try_into().unwrap();
+//! let geom = geo_types::Geometry::<f64>::try_from(geojson).unwrap();
 //! # }
 //! ```
 //!
@@ -466,6 +420,7 @@ pub use feature_reader::FeatureReader;
 mod feature_writer;
 pub use feature_writer::FeatureWriter;
 
+#[allow(deprecated)]
 #[cfg(feature = "geo-types")]
 pub use conversion::quick_collection;
 

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -47,7 +47,7 @@ mod roundtrip_tests {
     /// Verifies that we can parse and then re-encode geojson back to the same representation
     /// without losing any data.
     fn test_round_trip(file_path: &str) {
-        let mut file = File::open(&file_path).unwrap();
+        let mut file = File::open(file_path).unwrap();
         let mut file_contents = String::new();
         let _ = file.read_to_string(&mut file_contents);
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

The real motivation for this pull request, is that I was trying to look up some basic usage of the geojson crate and it took me uncomfortably long. Our [documentation](https://docs.rs/geojson/latest/geojson/) has grown over time and become a bit long winded in my experience.

So I was looking for ways to simplify our documentation, and noticed the couple paragraphs devoted to `quick_collection`.
Since `quick_collection` converts `&GeoJson -> Result<geo_types::GeometryCollection>`, I think it will be more discoverable under the idiomatic `TryFrom` trait, and because it's working like the idiomatic `TryFrom` trait, I think we can truncate some of the documentation.

