### PR TITLE
Added convenience wrappers for stringifying geojson

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED
 
+* Added `geojson::{to_string, to_string_pretty}` as convenience wrappers around the same `serde_json` methods.
+
 ## 0.24.0
 
 * Added `geojson::{ser, de}` helpers to convert your custom struct to and from GeoJSON. 

--- a/examples/geojson_to_string.rs
+++ b/examples/geojson_to_string.rs
@@ -1,0 +1,18 @@
+use std::error::Error;
+use std::fs::File;
+use std::io::BufReader;
+
+use geojson::{Feature, GeoJson};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let file_reader = BufReader::new(File::open("tests/fixtures/canonical/good-feature.geojson")?);
+
+    let feature: Feature = serde_json::from_reader(file_reader)?;
+    
+    let geojson: GeoJson = feature.into();
+
+    println!("{}", &geojson.clone().to_string()?);
+    println!("{}", &geojson.to_string_pretty()?);
+
+    Ok(())
+}

--- a/src/geojson.rs
+++ b/src/geojson.rs
@@ -227,6 +227,20 @@ impl GeoJson {
     {
         serde_json::from_reader(rdr)
     }
+
+    /// Convenience wrapper for [serde_json::to_string()]
+    pub fn to_string(self) -> Result<String> {
+        ::serde_json::to_string(&self)
+            .map_err(|err| Error::MalformedJson(err))
+            .and_then(|s| Ok(s.to_string()))
+    }
+
+    /// Convenience wrapper for [serde_json::to_string_pretty()]
+    pub fn to_string_pretty(self) -> Result<String> {
+        ::serde_json::to_string_pretty(&self)
+            .map_err(|err| Error::MalformedJson(err))
+            .and_then(|s| Ok(s.to_string()))
+    }
 }
 
 impl TryFrom<JsonObject> for GeoJson {


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Resolves #167. I'm not sure if it's still relevant but it looked like a good starting point.

This has the wrapper methods and an example but no tests.