### PR TITLE
For Discussion: Using `tinyvec::ArrayVec` for position to store positions on the stack

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = "~1.0"
 geo-types = { version = "0.7", features = ["serde"], optional = true }
 thiserror = "1.0.20"
 log = "0.4.17"
+tinyvec = { version = "1", features=["rustc_1_57", "serde"] }
 
 [dev-dependencies]
 num-traits = "0.2"

--- a/src/conversion/from_geo_types.rs
+++ b/src/conversion/from_geo_types.rs
@@ -1,4 +1,5 @@
 use geo_types::{self, CoordFloat};
+use tinyvec::array_vec;
 
 use crate::{geometry, Feature, FeatureCollection};
 
@@ -186,7 +187,7 @@ where
     let x: f64 = point.x().to_f64().unwrap();
     let y: f64 = point.y().to_f64().unwrap();
 
-    vec![x, y]
+    array_vec![x, y]
 }
 
 fn create_line_string_type<T>(line_string: &geo_types::LineString<T>) -> LineStringType

--- a/src/conversion/to_geo_types.rs
+++ b/src/conversion/to_geo_types.rs
@@ -363,12 +363,13 @@ fn mismatch_geom_err(expected_type: &'static str, found: &geometry::Value) -> Er
 mod tests {
     use crate::{Geometry, Value};
     use serde_json::json;
+    use tinyvec::array_vec;
 
     use std::convert::TryInto;
 
     #[test]
     fn geojson_point_conversion_test() {
-        let coords = vec![100.0, 0.2];
+        let coords = array_vec![100.0, 0.2];
         let geojson_point = Value::Point(coords.clone());
         let geo_point: geo_types::Point<f64> = geojson_point.try_into().unwrap();
 
@@ -378,8 +379,8 @@ mod tests {
 
     #[test]
     fn geojson_multi_point_conversion_test() {
-        let coord1 = vec![100.0, 0.2];
-        let coord2 = vec![101.0, 1.0];
+        let coord1 = array_vec![100.0, 0.2];
+        let coord2 = array_vec![101.0, 1.0];
         let geojson_multi_point = Value::MultiPoint(vec![coord1.clone(), coord2.clone()]);
         let geo_multi_point: geo_types::MultiPoint<f64> = geojson_multi_point.try_into().unwrap();
 
@@ -391,8 +392,8 @@ mod tests {
 
     #[test]
     fn geojson_line_string_conversion_test() {
-        let coord1 = vec![100.0, 0.2];
-        let coord2 = vec![101.0, 1.0];
+        let coord1 = array_vec![100.0, 0.2];
+        let coord2 = array_vec![101.0, 1.0];
         let geojson_line_string = Value::LineString(vec![coord1.clone(), coord2.clone()]);
         let geo_line_string: geo_types::LineString<f64> = geojson_line_string.try_into().unwrap();
 
@@ -404,9 +405,9 @@ mod tests {
 
     #[test]
     fn geojson_multi_line_string_conversion_test() {
-        let coord1 = vec![100.0, 0.2];
-        let coord2 = vec![101.0, 1.0];
-        let coord3 = vec![102.0, 0.8];
+        let coord1 = array_vec![100.0, 0.2];
+        let coord2 = array_vec![101.0, 1.0];
+        let coord3 = array_vec![102.0, 0.8];
         let geojson_multi_line_string = Value::MultiLineString(vec![
             vec![coord1.clone(), coord2.clone()],
             vec![coord2.clone(), coord3.clone()],
@@ -429,12 +430,12 @@ mod tests {
 
     #[test]
     fn geojson_polygon_conversion_test() {
-        let coord1 = vec![100.0, 0.0];
-        let coord2 = vec![101.0, 1.0];
-        let coord3 = vec![101.0, 1.0];
-        let coord4 = vec![104.0, 0.2];
-        let coord5 = vec![100.9, 0.2];
-        let coord6 = vec![100.9, 0.7];
+        let coord1 = array_vec![100.0, 0.0];
+        let coord2 = array_vec![101.0, 1.0];
+        let coord3 = array_vec![101.0, 1.0];
+        let coord4 = array_vec![104.0, 0.2];
+        let coord5 = array_vec![100.9, 0.2];
+        let coord6 = array_vec![100.9, 0.7];
 
         let geojson_multi_line_string_type1 = vec![
             vec![
@@ -484,9 +485,9 @@ mod tests {
 
     #[test]
     fn geojson_polygon_without_interiors_conversion_test() {
-        let coord1 = vec![100.0, 0.0];
-        let coord2 = vec![101.0, 1.0];
-        let coord3 = vec![101.0, 1.0];
+        let coord1 = array_vec![100.0, 0.0];
+        let coord2 = array_vec![101.0, 1.0];
+        let coord3 = array_vec![101.0, 1.0];
 
         let geojson_multi_line_string_type1 = vec![vec![
             coord1.clone(),
@@ -512,12 +513,12 @@ mod tests {
 
     #[test]
     fn geojson_multi_polygon_conversion_test() {
-        let coord1 = vec![100.0, 0.0];
-        let coord2 = vec![101.0, 1.0];
-        let coord3 = vec![101.0, 1.0];
-        let coord4 = vec![104.0, 0.2];
-        let coord5 = vec![100.9, 0.2];
-        let coord6 = vec![100.9, 0.7];
+        let coord1 = array_vec![100.0, 0.0];
+        let coord2 = array_vec![101.0, 1.0];
+        let coord3 = array_vec![101.0, 1.0];
+        let coord4 = array_vec![104.0, 0.2];
+        let coord5 = array_vec![100.9, 0.2];
+        let coord6 = array_vec![100.9, 0.7];
 
         let geojson_line_string_type1 = vec![
             coord1.clone(),
@@ -562,11 +563,11 @@ mod tests {
 
     #[test]
     fn geojson_geometry_collection_conversion_test() {
-        let coord1 = vec![100.0, 0.0];
-        let coord2 = vec![100.0, 1.0];
-        let coord3 = vec![101.0, 1.0];
-        let coord4 = vec![102.0, 0.0];
-        let coord5 = vec![101.0, 0.0];
+        let coord1 = array_vec![100.0, 0.0];
+        let coord2 = array_vec![100.0, 1.0];
+        let coord3 = array_vec![101.0, 1.0];
+        let coord4 = array_vec![102.0, 0.0];
+        let coord5 = array_vec![101.0, 0.0];
 
         let geojson_multi_point = Value::MultiPoint(vec![coord1.clone(), coord2.clone()]);
         let geojson_multi_line_string = Value::MultiLineString(vec![
@@ -602,7 +603,7 @@ mod tests {
 
     #[test]
     fn geojson_geometry_conversion() {
-        let coords = vec![100.0, 0.2];
+        let coords = array_vec![100.0, 0.2];
         let geojson_geometry = Geometry::from(Value::Point(coords.clone()));
         let geo_geometry: geo_types::Geometry<f64> = geojson_geometry
             .try_into()
@@ -615,8 +616,8 @@ mod tests {
 
     #[test]
     fn geojson_mismatch_geometry_conversion_test() {
-        let coord1 = vec![100.0, 0.2];
-        let coord2 = vec![101.0, 1.0];
+        let coord1 = array_vec![100.0, 0.2];
+        let coord2 = array_vec![101.0, 1.0];
         let geojson_line_string = Value::LineString(vec![coord1.clone(), coord2.clone()]);
         use std::convert::TryFrom;
         let error = geo_types::Point::<f64>::try_from(geojson_line_string).unwrap_err();
@@ -678,10 +679,10 @@ mod tests {
 
     #[test]
     fn borrowed_value_conversions_test() -> crate::Result<()> {
-        let coord1 = vec![100.0, 0.2];
-        let coord2 = vec![101.0, 1.0];
-        let coord3 = vec![102.0, 0.8];
-        let coord4 = vec![104.0, 0.2];
+        let coord1 = array_vec![100.0, 0.2];
+        let coord2 = array_vec![101.0, 1.0];
+        let coord3 = array_vec![102.0, 0.8];
+        let coord4 = array_vec![104.0, 0.2];
 
         let geojson_point = Value::Point(coord1.clone());
         let _: geo_types::Point<f64> = (&geojson_point).try_into()?;

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -225,6 +225,7 @@ mod tests {
     use crate::JsonObject;
     use crate::{feature, Error, Feature, GeoJson, Geometry, Value};
     use serde_json::json;
+    use tinyvec::array_vec;
 
     use std::str::FromStr;
 
@@ -252,7 +253,7 @@ mod tests {
     }
 
     fn value() -> Value {
-        Value::Point(vec![1.1, 2.1])
+        Value::Point(array_vec![1.1, 2.1])
     }
 
     fn geometry() -> Geometry {
@@ -347,7 +348,7 @@ mod tests {
         let feature_json_str = "{\"geometry\":{\"coordinates\":[1.1,2.1],\"type\":\"Point\"},\"id\":0,\"properties\":{},\"type\":\"Feature\"}";
         let feature = crate::Feature {
             geometry: Some(Geometry {
-                value: Value::Point(vec![1.1, 2.1]),
+                value: Value::Point(array_vec![1.1, 2.1]),
                 bbox: None,
                 foreign_members: None,
             }),
@@ -373,7 +374,7 @@ mod tests {
         let feature_json_str = "{\"geometry\":{\"coordinates\":[1.1,2.1],\"type\":\"Point\"},\"id\":\"foo\",\"properties\":{},\"type\":\"Feature\"}";
         let feature = crate::Feature {
             geometry: Some(Geometry {
-                value: Value::Point(vec![1.1, 2.1]),
+                value: Value::Point(array_vec![1.1, 2.1]),
                 bbox: None,
                 foreign_members: None,
             }),
@@ -424,7 +425,7 @@ mod tests {
         );
         let feature = crate::Feature {
             geometry: Some(Geometry {
-                value: Value::Point(vec![1.1, 2.1]),
+                value: Value::Point(array_vec![1.1, 2.1]),
                 bbox: None,
                 foreign_members: None,
             }),

--- a/src/feature_collection.rs
+++ b/src/feature_collection.rs
@@ -255,6 +255,7 @@ impl FromIterator<Feature> for FeatureCollection {
 mod tests {
     use crate::{Error, Feature, FeatureCollection, Value};
     use serde_json::json;
+    use tinyvec::array_vec;
 
     use std::str::FromStr;
 
@@ -262,13 +263,13 @@ mod tests {
     fn test_fc_from_iterator() {
         let features: Vec<Feature> = vec![
             {
-                let mut feat: Feature = Value::Point(vec![0., 0., 0.]).into();
+                let mut feat: Feature = Value::Point(array_vec![0., 0., 0.]).into();
                 feat.bbox = Some(vec![-1., -1., -1., 1., 1., 1.]);
                 feat
             },
             {
                 let mut feat: Feature =
-                    Value::MultiPoint(vec![vec![10., 10., 10.], vec![11., 11., 11.]]).into();
+                    Value::MultiPoint(vec![array_vec![10., 10., 10.], array_vec![11., 11., 11.]]).into();
                 feat.bbox = Some(vec![10., 10., 10., 11., 11., 11.]);
                 feat
             },

--- a/src/feature_iterator.rs
+++ b/src/feature_iterator.rs
@@ -130,6 +130,7 @@ where
 mod tests {
     use super::*;
     use crate::{Geometry, Value};
+    use tinyvec::array_vec;
 
     use std::io::BufReader;
 
@@ -187,7 +188,7 @@ mod tests {
         assert_eq!(
             Geometry {
                 bbox: None,
-                value: Value::Point(vec![102.0, 0.5]),
+                value: Value::Point(array_vec![102.0, 0.5]),
                 foreign_members: None,
             },
             fi.next().unwrap().unwrap().geometry.unwrap()
@@ -196,10 +197,10 @@ mod tests {
             Geometry {
                 bbox: None,
                 value: Value::LineString(vec![
-                    vec![102.0, 0.0],
-                    vec![103.0, 1.0],
-                    vec![104.0, 0.0],
-                    vec![105.0, 1.0]
+                  array_vec![102.0, 0.0],
+                  array_vec![103.0, 1.0],
+                  array_vec![104.0, 0.0],
+                  array_vec![105.0, 1.0]
                 ]),
                 foreign_members: None,
             },
@@ -209,11 +210,11 @@ mod tests {
             Geometry {
                 bbox: None,
                 value: Value::Polygon(vec![vec![
-                    vec![100.0, 0.0],
-                    vec![101.0, 0.0],
-                    vec![101.0, 1.0],
-                    vec![100.0, 1.0],
-                    vec![100.0, 0.0]
+                  array_vec![100.0, 0.0],
+                  array_vec![101.0, 0.0],
+                  array_vec![101.0, 1.0],
+                  array_vec![100.0, 1.0],
+                  array_vec![100.0, 0.0]
                 ]]),
                 foreign_members: None,
             },

--- a/src/feature_writer.rs
+++ b/src/feature_writer.rs
@@ -229,6 +229,7 @@ mod tests {
     use crate::JsonValue;
 
     use serde_json::json;
+    use tinyvec::array_vec;
 
     // an example struct that we want to serialize
     #[derive(Serialize)]
@@ -284,7 +285,7 @@ mod tests {
 
                 Feature {
                     bbox: None,
-                    geometry: Some(crate::Geometry::from(crate::Value::Point(vec![1.1, 1.2]))),
+                    geometry: Some(crate::Geometry::from(crate::Value::Point(array_vec![1.1, 1.2]))),
                     id: None,
                     properties: Some(props),
                     foreign_members: None,
@@ -298,7 +299,7 @@ mod tests {
 
                 Feature {
                     bbox: None,
-                    geometry: Some(crate::Geometry::from(crate::Value::Point(vec![2.1, 2.2]))),
+                    geometry: Some(crate::Geometry::from(crate::Value::Point(array_vec![2.1, 2.2]))),
                     id: None,
                     properties: Some(props),
                     foreign_members: None,
@@ -340,12 +341,12 @@ mod tests {
         {
             let mut writer = FeatureWriter::from_writer(&mut buffer);
             let record_1 = MyRecord {
-                geometry: crate::Geometry::from(crate::Value::Point(vec![1.1, 1.2])),
+                geometry: crate::Geometry::from(crate::Value::Point(array_vec![1.1, 1.2])),
                 name: "Mishka".to_string(),
                 age: 12,
             };
             let record_2 = MyRecord {
-                geometry: crate::Geometry::from(crate::Value::Point(vec![2.1, 2.2])),
+                geometry: crate::Geometry::from(crate::Value::Point(array_vec![2.1, 2.2])),
                 name: "Jane".to_string(),
                 age: 22,
             };

--- a/src/geojson.rs
+++ b/src/geojson.rs
@@ -396,6 +396,7 @@ mod tests {
     use serde_json::json;
     use std::convert::TryInto;
     use std::str::FromStr;
+    use tinyvec::array_vec;
 
     #[test]
     fn test_geojson_from_reader() {
@@ -443,7 +444,7 @@ mod tests {
             geojson,
             GeoJson::Feature(Feature {
                 bbox: None,
-                geometry: Some(Geometry::new(Value::Point(vec![102.0, 0.5]))),
+                geometry: Some(Geometry::new(Value::Point(array_vec![102.0, 0.5]))),
                 id: None,
                 properties: None,
                 foreign_members: None,
@@ -468,7 +469,7 @@ mod tests {
             geojson,
             GeoJson::Feature(Feature {
                 bbox: None,
-                geometry: Some(Geometry::new(Value::Point(vec![102.0, 0.5]))),
+                geometry: Some(Geometry::new(Value::Point(array_vec![102.0, 0.5]))),
                 id: None,
                 properties: None,
                 foreign_members: None,

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -364,6 +364,7 @@ mod tests {
     use crate::{Error, GeoJson, Geometry, JsonObject, Value};
     use serde_json::json;
     use std::str::FromStr;
+    use tinyvec::array_vec;
 
     fn encode(geometry: &Geometry) -> String {
         serde_json::to_string(&geometry).unwrap()
@@ -376,7 +377,7 @@ mod tests {
     fn encode_decode_geometry() {
         let geometry_json_str = "{\"coordinates\":[1.1,2.1],\"type\":\"Point\"}";
         let geometry = Geometry {
-            value: Value::Point(vec![1.1, 2.1]),
+            value: Value::Point(array_vec![1.1, 2.1]),
             bbox: None,
             foreign_members: None,
         };
@@ -410,7 +411,7 @@ mod tests {
         assert_eq!(
             geometry,
             Geometry {
-                value: Value::Point(vec![0.0, 0.1]),
+                value: Value::Point(array_vec![0.0, 0.1]),
                 bbox: None,
                 foreign_members: None,
             }
@@ -419,7 +420,7 @@ mod tests {
 
     #[test]
     fn test_geometry_display() {
-        let v = Value::LineString(vec![vec![0.0, 0.1], vec![0.1, 0.2], vec![0.2, 0.3]]);
+        let v = Value::LineString(vec![array_vec![0.0, 0.1], array_vec![0.1, 0.2], array_vec![0.2, 0.3]]);
         let geometry = Geometry::new(v);
         assert_eq!(
             "{\"coordinates\":[[0.0,0.1],[0.1,0.2],[0.2,0.3]],\"type\":\"LineString\"}",
@@ -429,7 +430,7 @@ mod tests {
 
     #[test]
     fn test_value_display() {
-        let v = Value::LineString(vec![vec![0.0, 0.1], vec![0.1, 0.2], vec![0.2, 0.3]]);
+        let v = Value::LineString(vec![array_vec![0.0, 0.1], array_vec![0.1, 0.2], array_vec![0.2, 0.3]]);
         assert_eq!(
             "{\"coordinates\":[[0.0,0.1],[0.1,0.2],[0.2,0.3]],\"type\":\"LineString\"}",
             v.to_string()
@@ -446,7 +447,7 @@ mod tests {
             serde_json::to_value(true).unwrap(),
         );
         let geometry = Geometry {
-            value: Value::Point(vec![1.1, 2.1]),
+            value: Value::Point(array_vec![1.1, 2.1]),
             bbox: None,
             foreign_members: Some(foreign_members),
         };
@@ -470,12 +471,12 @@ mod tests {
             value: Value::GeometryCollection(vec![
                 Geometry {
                     bbox: None,
-                    value: Value::Point(vec![100.0, 0.0]),
+                    value: Value::Point(array_vec![100.0, 0.0]),
                     foreign_members: None,
                 },
                 Geometry {
                     bbox: None,
-                    value: Value::LineString(vec![vec![101.0, 0.0], vec![102.0, 1.0]]),
+                    value: Value::LineString(vec![array_vec![101.0, 0.0], array_vec![102.0, 1.0]]),
                     foreign_members: None,
                 },
             ]),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,7 +424,7 @@ pub type Bbox = Vec<f64>;
 /// Positions
 ///
 /// [GeoJSON Format Specification § 3.1.1](https://tools.ietf.org/html/rfc7946#section-3.1.1)
-pub type Position = Vec<f64>;
+pub type Position = ArrayVec<[f64; 4]>;
 
 pub type PointType = Position;
 pub type LineStringType = Vec<Position>;
@@ -468,6 +468,7 @@ pub use feature_writer::FeatureWriter;
 
 #[cfg(feature = "geo-types")]
 pub use conversion::quick_collection;
+use tinyvec::ArrayVec;
 
 /// Feature Objects
 ///

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -365,6 +365,7 @@ mod tests {
     use crate::JsonValue;
 
     use serde_json::json;
+    use tinyvec::array_vec;
 
     use std::str::FromStr;
 
@@ -377,7 +378,7 @@ mod tests {
         }
 
         let my_feature = {
-            let geometry = crate::Geometry::new(crate::Value::Point(vec![0.0, 1.0]));
+            let geometry = crate::Geometry::new(crate::Value::Point(array_vec![0.0, 1.0]));
             let name = "burbs".to_string();
             MyStruct { geometry, name }
         };
@@ -409,7 +410,7 @@ mod tests {
         #[test]
         fn with_some_geom() {
             let my_feature = {
-                let geometry = Some(crate::Geometry::new(crate::Value::Point(vec![0.0, 1.0])));
+                let geometry = Some(crate::Geometry::new(crate::Value::Point(array_vec![0.0, 1.0])));
                 let name = "burbs".to_string();
                 MyStruct { geometry, name }
             };

--- a/src/util.rs
+++ b/src/util.rs
@@ -210,7 +210,10 @@ pub fn get_features(object: &mut JsonObject) -> Result<Vec<Feature>> {
 
 fn json_to_position(json: &JsonValue) -> Result<Position> {
     let coords_array = expect_array(json)?;
-    let mut coords = Vec::with_capacity(coords_array.len());
+
+    // TODO: Check to make sure there are not more than 4 coordinates.
+
+    let mut coords = Position::default();
     for position in coords_array {
         coords.push(expect_f64(position)?);
     }


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This is a PR for discussion.  I've moved `Position` from being a `Vec<f64>` to being an `ArrayVec<f64>` with a capacity of 4 elements (x, y, z, t).   This means that instead of every point resulting in an allocation, points are stored on the stack and we only allocate to create `LineString`, `Polygon` etc.

Preliminary cargo-bench results suggest performance improvements up to 79% in some cases.   

If there is agreement that this is a good direction, I'll add some convenience functions like `Position::from_vec` etc to recover some of the ergonomics of working with Vecs. 

Benchmarks:

```
Benchmarking parse (countries.geojson)
Benchmarking parse (countries.geojson): Warming up for 3.0000 s
Benchmarking parse (countries.geojson): Collecting 100 samples in estimated 5.1934 s (2600 iterations)
Benchmarking parse (countries.geojson): Analyzing
parse (countries.geojson)
                        time:   [1.9881 ms 1.9981 ms 2.0086 ms]
                        change: [-13.706% -13.086% -12.475%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

Benchmarking FeatureReader::features (countries.geojson)
Benchmarking FeatureReader::features (countries.geojson): Warming up for 3.0000 s
Benchmarking FeatureReader::features (countries.geojson): Collecting 100 samples in estimated 5.5955 s (900 iterations)
Benchmarking FeatureReader::features (countries.geojson): Analyzing
FeatureReader::features (countries.geojson)
                        time:   [6.1732 ms 6.1837 ms 6.1956 ms]
                        change: [-6.3597% -6.0745% -5.7713%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  7 (7.00%) high mild
  2 (2.00%) high severe

Benchmarking FeatureReader::deserialize (countries.geojson)
Benchmarking FeatureReader::deserialize (countries.geojson): Warming up for 3.0000 s
Benchmarking FeatureReader::deserialize (countries.geojson): Collecting 100 samples in estimated 5.5427 s (700 iterations)
Benchmarking FeatureReader::deserialize (countries.geojson): Analyzing
FeatureReader::deserialize (countries.geojson)
                        time:   [8.1079 ms 8.1365 ms 8.1734 ms]
                        change: [-2.0054% -1.5319% -0.9778%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

Benchmarking FeatureReader::deserialize to geo-types (countries.geojson)
Benchmarking FeatureReader::deserialize to geo-types (countries.geojson): Warming up for 3.0000 s
Benchmarking FeatureReader::deserialize to geo-types (countries.geojson): Collecting 100 samples in estimated 5.5704 s (700 iterations)
Benchmarking FeatureReader::deserialize to geo-types (countries.geojson): Analyzing
FeatureReader::deserialize to geo-types (countries.geojson)
                        time:   [7.9112 ms 7.9288 ms 7.9473 ms]
                        change: [-2.6196% -2.3486% -2.0713%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

Benchmarking parse (geometry_collection.geojson)
Benchmarking parse (geometry_collection.geojson): Warming up for 3.0000 s
Benchmarking parse (geometry_collection.geojson): Collecting 100 samples in estimated 5.0480 s (293k iterations)
Benchmarking parse (geometry_collection.geojson): Analyzing
parse (geometry_collection.geojson)
                        time:   [17.236 µs 17.274 µs 17.320 µs]
                        change: [-7.0696% -6.7231% -6.3747%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
Benchmarking serialize geojson::FeatureCollection struct (countries.geojson)
Benchmarking serialize geojson::FeatureCollection struct (countries.geojson): Warming up for 3.0000 s
Benchmarking serialize geojson::FeatureCollection struct (countries.geojson): Collecting 100 samples in estimated 5.0413 s (1700 iterations)
Benchmarking serialize geojson::FeatureCollection struct (countries.geojson): Analyzing
serialize geojson::FeatureCollection struct (countries.geojson)
                        time:   [2.9583 ms 2.9634 ms 2.9690 ms]
                        change: [-2.4235% -1.8933% -1.3582%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe

Benchmarking serialize custom struct (countries.geojson)
Benchmarking serialize custom struct (countries.geojson): Warming up for 3.0000 s
Benchmarking serialize custom struct (countries.geojson): Collecting 100 samples in estimated 5.1482 s (2300 iterations)
Benchmarking serialize custom struct (countries.geojson): Analyzing
serialize custom struct (countries.geojson)
                        time:   [2.2299 ms 2.2331 ms 2.2364 ms]
                        change: [-2.4677% -2.2513% -2.0310%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

Benchmarking serialize custom struct to geo-types (countries.geojson)
Benchmarking serialize custom struct to geo-types (countries.geojson): Warming up for 3.0000 s
Benchmarking serialize custom struct to geo-types (countries.geojson): Collecting 100 samples in estimated 5.0427 s (2200 iterations)
Benchmarking serialize custom struct to geo-types (countries.geojson): Analyzing
serialize custom struct to geo-types (countries.geojson)
                        time:   [2.2959 ms 2.3017 ms 2.3081 ms]
                        change: [-11.260% -11.003% -10.713%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  7 (7.00%) high mild
  2 (2.00%) high severe

WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
Benchmarking quick_collection
Benchmarking quick_collection: Warming up for 3.0000 s
Benchmarking quick_collection: Collecting 100 samples in estimated 5.1283 s (71k iterations)
Benchmarking quick_collection: Analyzing
quick_collection        time:   [72.840 µs 73.421 µs 74.013 µs]
                        change: [-79.655% -79.490% -79.317%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
  ```
