### PR TITLE
WIP: parse points without heap allocation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tinyvec = { version = "1.6.0", features = ["serde", "alloc"] }
 [dev-dependencies]
 num-traits = "0.2"
 criterion = "0.4.0"
+pretty_env_logger = "0.4.0"
 
 [[bench]]
 name = "parse"

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -9,12 +9,10 @@ fn parse_feature_collection_benchmark(c: &mut Criterion) {
     let geojson_str = include_str!("../tests/fixtures/countries.geojson");
 
     c.bench_function("parse (countries.geojson)", |b| {
-        b.iter(|| match geojson_str.parse::<geojson::GeoJson>() {
-            Ok(GeoJson::FeatureCollection(fc)) => {
-                assert_eq!(fc.features.len(), 180);
-                black_box(fc)
-            }
-            _ => panic!("unexpected result"),
+        b.iter(|| {
+            let fc = geojson_str.parse::<geojson::FeatureCollection>().unwrap();
+            assert_eq!(fc.features.len(), 180);
+            black_box(fc);
         })
     });
 

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -30,52 +30,52 @@ fn parse_feature_collection_benchmark(c: &mut Criterion) {
         });
     });
 
-    c.bench_function("FeatureReader::deserialize (countries.geojson)", |b| {
-        b.iter(|| {
-            #[allow(unused)]
-            #[derive(serde::Deserialize)]
-            struct Country {
-                geometry: geojson::Geometry,
-                name: String,
-            }
-            let feature_reader =
-                geojson::FeatureReader::from_reader(BufReader::new(geojson_str.as_bytes()));
+    // c.bench_function("FeatureReader::deserialize (countries.geojson)", |b| {
+    //     b.iter(|| {
+    //         #[allow(unused)]
+    //         #[derive(serde::Deserialize)]
+    //         struct Country {
+    //             geometry: geojson::Geometry,
+    //             name: String,
+    //         }
+    //         let feature_reader =
+    //             geojson::FeatureReader::from_reader(BufReader::new(geojson_str.as_bytes()));
+    //
+    //         let mut count = 0;
+    //         for feature in feature_reader.deserialize::<Country>().unwrap() {
+    //             let feature = feature.unwrap();
+    //             black_box(feature);
+    //             count += 1;
+    //         }
+    //         assert_eq!(count, 180);
+    //     });
+    // });
 
-            let mut count = 0;
-            for feature in feature_reader.deserialize::<Country>().unwrap() {
-                let feature = feature.unwrap();
-                black_box(feature);
-                count += 1;
-            }
-            assert_eq!(count, 180);
-        });
-    });
-
-    #[cfg(feature = "geo-types")]
-    c.bench_function(
-        "FeatureReader::deserialize to geo-types (countries.geojson)",
-        |b| {
-            b.iter(|| {
-                #[allow(unused)]
-                #[derive(serde::Deserialize)]
-                struct Country {
-                    #[serde(deserialize_with = "deserialize_geometry")]
-                    geometry: geo_types::Geometry,
-                    name: String,
-                }
-                let feature_reader =
-                    geojson::FeatureReader::from_reader(BufReader::new(geojson_str.as_bytes()));
-
-                let mut count = 0;
-                for feature in feature_reader.deserialize::<Country>().unwrap() {
-                    let feature = feature.unwrap();
-                    black_box(feature);
-                    count += 1;
-                }
-                assert_eq!(count, 180);
-            });
-        },
-    );
+    // #[cfg(feature = "geo-types")]
+    // c.bench_function(
+    //     "FeatureReader::deserialize to geo-types (countries.geojson)",
+    //     |b| {
+    //         b.iter(|| {
+    //             #[allow(unused)]
+    //             #[derive(serde::Deserialize)]
+    //             struct Country {
+    //                 #[serde(deserialize_with = "deserialize_geometry")]
+    //                 geometry: geo_types::Geometry,
+    //                 name: String,
+    //             }
+    //             let feature_reader =
+    //                 geojson::FeatureReader::from_reader(BufReader::new(geojson_str.as_bytes()));
+    //
+    //             let mut count = 0;
+    //             for feature in feature_reader.deserialize::<Country>().unwrap() {
+    //                 let feature = feature.unwrap();
+    //                 black_box(feature);
+    //                 count += 1;
+    //             }
+    //             assert_eq!(count, 180);
+    //         });
+    //     },
+    // );
 }
 
 fn parse_geometry_collection_benchmark(c: &mut Criterion) {

--- a/benches/serialize.rs
+++ b/benches/serialize.rs
@@ -18,56 +18,56 @@ fn serialize_feature_collection_benchmark(c: &mut Criterion) {
         },
     );
 
-    c.bench_function("serialize custom struct (countries.geojson)", |b| {
-        #[derive(serde::Serialize, serde::Deserialize)]
-        struct Country {
-            geometry: geojson::Geometry,
-            name: String,
-        }
-        let features =
-            geojson::de::deserialize_feature_collection_str_to_vec::<Country>(geojson_str).unwrap();
-        assert_eq!(features.len(), 180);
+    // c.bench_function("serialize custom struct (countries.geojson)", |b| {
+    //     #[derive(serde::Serialize, serde::Deserialize)]
+    //     struct Country {
+    //         geometry: geojson::Geometry,
+    //         name: String,
+    //     }
+    //     let features =
+    //         geojson::de::deserialize_feature_collection_str_to_vec::<Country>(geojson_str).unwrap();
+    //     assert_eq!(features.len(), 180);
+    //
+    //     b.iter(|| {
+    //         let geojson_string = geojson::ser::to_feature_collection_string(&features).unwrap();
+    //         // Sanity check that we serialized a long string of some kind.
+    //         //
+    //         // Note this is slightly shorter than the GeoJson round-trip above because we drop
+    //         // some fields, like foreign members
+    //         assert_eq!(geojson_string.len(), 254908);
+    //         black_box(geojson_string);
+    //     });
+    // });
 
-        b.iter(|| {
-            let geojson_string = geojson::ser::to_feature_collection_string(&features).unwrap();
-            // Sanity check that we serialized a long string of some kind.
-            //
-            // Note this is slightly shorter than the GeoJson round-trip above because we drop
-            // some fields, like foreign members
-            assert_eq!(geojson_string.len(), 254908);
-            black_box(geojson_string);
-        });
-    });
-
-    #[cfg(feature = "geo-types")]
-    c.bench_function(
-        "serialize custom struct to geo-types (countries.geojson)",
-        |b| {
-            #[derive(serde::Serialize, serde::Deserialize)]
-            struct Country {
-                #[serde(
-                    serialize_with = "serialize_geometry",
-                    deserialize_with = "deserialize_geometry"
-                )]
-                geometry: geo_types::Geometry,
-                name: String,
-            }
-            let features =
-                geojson::de::deserialize_feature_collection_str_to_vec::<Country>(geojson_str)
-                    .unwrap();
-            assert_eq!(features.len(), 180);
-
-            b.iter(|| {
-                let geojson_string = geojson::ser::to_feature_collection_string(&features).unwrap();
-                // Sanity check that we serialized a long string of some kind.
-                //
-                // Note this is slightly shorter than the GeoJson round-trip above because we drop
-                // some fields, like foreign members
-                assert_eq!(geojson_string.len(), 254908);
-                black_box(geojson_string);
-            });
-        },
-    );
+    // #[cfg(feature = "geo-types")]
+    // c.bench_function(
+    //     "serialize custom struct to geo-types (countries.geojson)",
+    //     |b| {
+    //         #[derive(serde::Serialize, serde::Deserialize)]
+    //         struct Country {
+    //             #[serde(
+    //                 serialize_with = "serialize_geometry",
+    //                 deserialize_with = "deserialize_geometry"
+    //             )]
+    //             geometry: geo_types::Geometry,
+    //             name: String,
+    //         }
+    //         let features =
+    //             geojson::de::deserialize_feature_collection_str_to_vec::<Country>(geojson_str)
+    //                 .unwrap();
+    //         assert_eq!(features.len(), 180);
+    //
+    //         b.iter(|| {
+    //             let geojson_string = geojson::ser::to_feature_collection_string(&features).unwrap();
+    //             // Sanity check that we serialized a long string of some kind.
+    //             //
+    //             // Note this is slightly shorter than the GeoJson round-trip above because we drop
+    //             // some fields, like foreign members
+    //             assert_eq!(geojson_string.len(), 254908);
+    //             black_box(geojson_string);
+    //         });
+    //     },
+    // );
 }
 
 criterion_group!(benches, serialize_feature_collection_benchmark);

--- a/src/conversion/from_geo_types.rs
+++ b/src/conversion/from_geo_types.rs
@@ -270,8 +270,8 @@ where
 mod tests {
     use crate::{GeoJson, Geometry, Value};
     use geo_types::{
-        Coord, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
-        MultiPolygon, Point, Polygon, Rect, Triangle,
+        Coord, GeometryCollection, Line, LineString, MultiLineString, MultiPoint, MultiPolygon,
+        Point, Polygon, Rect, Triangle,
     };
 
     #[test]

--- a/src/conversion/from_geo_types.rs
+++ b/src/conversion/from_geo_types.rs
@@ -193,7 +193,7 @@ where
     T: CoordFloat,
 {
     line_string
-        .points_iter()
+        .points()
         .map(|point| create_point_type(&point))
         .collect()
 }
@@ -241,7 +241,7 @@ where
 {
     let mut coords = vec![polygon
         .exterior()
-        .points_iter()
+        .points()
         .map(|point| create_point_type(&point))
         .collect()];
 
@@ -270,7 +270,7 @@ where
 mod tests {
     use crate::{GeoJson, Geometry, Value};
     use geo_types::{
-        Coordinate, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
+        Coord, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
         MultiPolygon, Point, Polygon, Rect, Triangle,
     };
 
@@ -355,9 +355,9 @@ mod tests {
 
     #[test]
     fn geo_triangle_conversion_test() {
-        let c1 = Coordinate { x: 0., y: 0. };
-        let c2 = Coordinate { x: 10., y: 20. };
-        let c3 = Coordinate { x: 20., y: -10. };
+        let c1 = Coord { x: 0., y: 0. };
+        let c2 = Coord { x: 10., y: 20. };
+        let c3 = Coord { x: 20., y: -10. };
 
         let triangle = Triangle(c1, c2, c3);
 
@@ -380,8 +380,8 @@ mod tests {
 
     #[test]
     fn geo_rect_conversion_test() {
-        let c1 = Coordinate { x: 0., y: 0. };
-        let c2 = Coordinate { x: 10., y: 20. };
+        let c1 = Coord { x: 0., y: 0. };
+        let c2 = Coord { x: 10., y: 20. };
 
         let rect = Rect::new(c1, c2);
 

--- a/src/conversion/to_geo_types.rs
+++ b/src/conversion/to_geo_types.rs
@@ -273,11 +273,11 @@ where
     }
 }
 
-fn create_geo_coordinate<T>(point_type: &PointType) -> geo_types::Coordinate<T>
+fn create_geo_coordinate<T>(point_type: &PointType) -> geo_types::Coord<T>
 where
     T: CoordFloat,
 {
-    geo_types::Coordinate {
+    geo_types::Coord {
         x: T::from(point_type[0]).unwrap(),
         y: T::from(point_type[1]).unwrap(),
     }

--- a/src/de.rs
+++ b/src/de.rs
@@ -89,7 +89,7 @@ use std::fmt::Formatter;
 use std::io::Read;
 use std::marker::PhantomData;
 
-use serde::de::{Deserialize, DeserializeOwned, Deserializer, Error, IntoDeserializer};
+use serde::de::{Deserialize, DeserializeOwned, Deserializer, Error};
 
 /// Deserialize a GeoJSON FeatureCollection into your custom structs.
 ///
@@ -332,6 +332,7 @@ impl<'de> serde::de::Visitor<'de> for FeatureVisitor<Feature> {
                 "geometry" => {
                     log::debug!("had geometry");
                     geometry = Some(map_access.next_value()?);
+                    log::debug!("got geometry");
                 }
                 "id" => {
                     log::debug!("had id");

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,7 @@
 //! Module for all GeoJSON-related errors
 use crate::Feature;
 use serde_json::value::Value;
+use std::fmt::Display;
 use thiserror::Error;
 
 /// Errors which can occur when encoding, decoding, and converting GeoJSON
@@ -62,6 +63,15 @@ pub type Result<T> = std::result::Result<T, Error>;
 impl From<serde_json::Error> for Error {
     fn from(error: serde_json::Error) -> Self {
         Self::MalformedJson(error)
+    }
+}
+
+impl serde::de::Error for Error {
+    fn custom<T>(msg: T) -> Self
+    where
+        T: Display,
+    {
+        Self::MalformedJson(serde_json::Error::custom(msg))
     }
 }
 

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -200,6 +200,7 @@ impl<'de> Deserialize<'de> for Feature {
 ///
 /// [GeoJSON Format Specification § 3.2](https://tools.ietf.org/html/rfc7946#section-3.2)
 #[derive(Clone, Debug, PartialEq, Deserialize)]
+#[serde(untagged)]
 pub enum Id {
     String(String),
     Number(serde_json::Number),

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -20,6 +20,7 @@ use crate::{util, Feature, Geometry, Value};
 use crate::{JsonObject, JsonValue};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::json;
+use crate::de::FeatureVisitor;
 
 impl From<Geometry> for Feature {
     fn from(geom: Geometry) -> Feature {
@@ -191,11 +192,7 @@ impl<'de> Deserialize<'de> for Feature {
     where
         D: Deserializer<'de>,
     {
-        use serde::de::Error as SerdeError;
-
-        let val = JsonObject::deserialize(deserializer)?;
-
-        Feature::from_json_object(val).map_err(|e| D::Error::custom(e.to_string()))
+        deserializer.deserialize_map( FeatureVisitor::new())
     }
 }
 

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -15,12 +15,12 @@
 use std::convert::TryFrom;
 use std::str::FromStr;
 
+use crate::de::FeatureVisitor;
 use crate::errors::{Error, Result};
 use crate::{util, Feature, Geometry, Value};
 use crate::{JsonObject, JsonValue};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::json;
-use crate::de::FeatureVisitor;
 
 impl From<Geometry> for Feature {
     fn from(geom: Geometry) -> Feature {
@@ -192,18 +192,20 @@ impl<'de> Deserialize<'de> for Feature {
     where
         D: Deserializer<'de>,
     {
-        deserializer.deserialize_map( FeatureVisitor::new())
+        deserializer.deserialize_map(FeatureVisitor::new())
     }
 }
 
 /// Feature identifier
 ///
 /// [GeoJSON Format Specification § 3.2](https://tools.ietf.org/html/rfc7946#section-3.2)
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Deserialize)]
 pub enum Id {
     String(String),
     Number(serde_json::Number),
 }
+
+// REVIEW: test deserializing both numeric and string based ids
 
 impl Serialize for Id {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>

--- a/src/feature_collection.rs
+++ b/src/feature_collection.rs
@@ -160,7 +160,7 @@ impl FromStr for FeatureCollection {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self> {
-        Self::try_from(crate::GeoJson::from_str(s)?)
+        Ok(serde_json::from_reader(s.as_bytes())?)
     }
 }
 

--- a/src/feature_collection.rs
+++ b/src/feature_collection.rs
@@ -61,7 +61,8 @@ use serde_json::json;
 ///     .collect();
 /// assert_eq!(fc.features.len(), 10);
 /// ```
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+#[serde(tag="type")]
 pub struct FeatureCollection {
     /// Bounding Box
     ///
@@ -172,18 +173,18 @@ impl Serialize for FeatureCollection {
     }
 }
 
-impl<'de> Deserialize<'de> for FeatureCollection {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<FeatureCollection, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        use serde::de::Error as SerdeError;
-
-        let val = JsonObject::deserialize(deserializer)?;
-
-        FeatureCollection::from_json_object(val).map_err(|e| D::Error::custom(e.to_string()))
-    }
-}
+// impl<'de> Deserialize<'de> for FeatureCollection {
+//     fn deserialize<D>(deserializer: D) -> std::result::Result<FeatureCollection, D::Error>
+//     where
+//         D: Deserializer<'de>,
+//     {
+//         use serde::de::Error as SerdeError;
+//
+//         let val = JsonObject::deserialize(deserializer)?;
+//
+//         FeatureCollection::from_json_object(val).map_err(|e| D::Error::custom(e.to_string()))
+//     }
+// }
 
 /// Create a [`FeatureCollection`] using the [`collect`]
 /// method on an iterator of `Feature`s. If every item

--- a/src/feature_collection.rs
+++ b/src/feature_collection.rs
@@ -19,7 +19,7 @@ use std::str::FromStr;
 use crate::errors::{Error, Result};
 use crate::{util, Bbox, Feature};
 use crate::{JsonObject, JsonValue};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize, Serializer};
 use serde_json::json;
 
 /// Feature Collection Objects
@@ -62,7 +62,7 @@ use serde_json::json;
 /// assert_eq!(fc.features.len(), 10);
 /// ```
 #[derive(Clone, Debug, PartialEq, Deserialize)]
-#[serde(tag="type")]
+#[serde(tag = "type")]
 pub struct FeatureCollection {
     /// Bounding Box
     ///

--- a/src/geojson.rs
+++ b/src/geojson.rs
@@ -43,7 +43,8 @@ use std::str::FromStr;
 /// let feature2: Feature = geojson.try_into().unwrap();
 /// ```
 /// [GeoJSON Format Specification § 3](https://tools.ietf.org/html/rfc7946#section-3)
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+#[serde(tag="type")]
 pub enum GeoJson {
     Geometry(Geometry),
     Feature(Feature),
@@ -299,18 +300,18 @@ impl Serialize for GeoJson {
     }
 }
 
-impl<'de> Deserialize<'de> for GeoJson {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<GeoJson, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        use serde::de::Error as SerdeError;
-
-        let val = JsonObject::deserialize(deserializer)?;
-
-        GeoJson::from_json_object(val).map_err(|e| D::Error::custom(e.to_string()))
-    }
-}
+// impl<'de> Deserialize<'de> for GeoJson {
+//     fn deserialize<D>(deserializer: D) -> std::result::Result<GeoJson, D::Error>
+//     where
+//         D: Deserializer<'de>,
+//     {
+//         use serde::de::Error as SerdeError;
+//
+//         let val = JsonObject::deserialize(deserializer)?;
+//
+//         GeoJson::from_json_object(val).map_err(|e| D::Error::custom(e.to_string()))
+//     }
+// }
 
 /// # Example
 ///```
@@ -345,9 +346,7 @@ impl FromStr for GeoJson {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self> {
-        let object = get_object(s)?;
-
-        GeoJson::from_json_object(object)
+        Ok(serde_json::from_reader(s.as_bytes())?)
     }
 }
 

--- a/src/geojson.rs
+++ b/src/geojson.rs
@@ -499,4 +499,18 @@ mod tests {
             Err(Error::MalformedJson(_))
         ))
     }
+
+    #[test]
+    fn countries() {
+        let geojson_str = include_str!("../tests/fixtures/countries.geojson");
+        match geojson_str.parse::<GeoJson>() {
+            Ok(GeoJson::FeatureCollection(fc)) => {
+                assert_eq!(fc.features.len(), 180);
+            }
+            Ok(other) => {
+                panic!("unexpectd result: {other:?}")
+            }
+            Err(err) => panic!("err: {:?}", err),
+        }
+    }
 }

--- a/src/geojson.rs
+++ b/src/geojson.rs
@@ -15,7 +15,7 @@
 use crate::errors::{Error, Result};
 use crate::{Feature, FeatureCollection, Geometry};
 use crate::{JsonObject, JsonValue};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize, Serializer};
 use std::convert::TryFrom;
 use std::fmt;
 use std::iter::FromIterator;
@@ -44,7 +44,7 @@ use std::str::FromStr;
 /// ```
 /// [GeoJSON Format Specification § 3](https://tools.ietf.org/html/rfc7946#section-3)
 #[derive(Clone, Debug, PartialEq, Deserialize)]
-#[serde(tag="type")]
+#[serde(tag = "type")]
 pub enum GeoJson {
     Geometry(Geometry),
     Feature(Feature),
@@ -350,13 +350,6 @@ impl FromStr for GeoJson {
     }
 }
 
-fn get_object(s: &str) -> Result<JsonObject> {
-    match ::serde_json::from_str(s)? {
-        JsonValue::Object(object) => Ok(object),
-        other => Err(Error::ExpectedObjectValue(other)),
-    }
-}
-
 impl fmt::Display for GeoJson {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         ::serde_json::to_string(self)
@@ -391,7 +384,7 @@ impl fmt::Display for FeatureCollection {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Error, Feature, GeoJson, Geometry, Position, Value};
+    use crate::{Error, Feature, FeatureCollection, GeoJson, Geometry, Position, Value};
     use serde_json::json;
     use std::convert::TryInto;
     use std::str::FromStr;
@@ -501,15 +494,9 @@ mod tests {
 
     #[test]
     fn countries() {
+        pretty_env_logger::init();
         let geojson_str = include_str!("../tests/fixtures/countries.geojson");
-        match geojson_str.parse::<GeoJson>() {
-            Ok(GeoJson::FeatureCollection(fc)) => {
-                assert_eq!(fc.features.len(), 180);
-            }
-            Ok(other) => {
-                panic!("unexpectd result: {other:?}")
-            }
-            Err(err) => panic!("err: {:?}", err),
-        }
+        let fc = geojson_str.parse::<FeatureCollection>().unwrap();
+        assert_eq!(fc.features.len(), 180);
     }
 }

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt::Formatter;
 use std::str::FromStr;
 use std::{convert::TryFrom, fmt};
 
@@ -255,6 +256,48 @@ pub struct Geometry {
     pub foreign_members: Option<JsonObject>,
 }
 
+#[derive(Debug, Clone, Copy)]
+enum GeometryType {
+    Point,
+    MultiPoint,
+    LineString,
+    MultiLineString,
+    Polygon,
+    MultiPolygon,
+    GeometryCollection,
+}
+
+impl FromStr for GeometryType {
+    type Err = Error;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        Ok(match s {
+            "Point" => Self::Point,
+            "MultiPoint" => Self::MultiPoint,
+            "LineString" => Self::LineString,
+            "MultiLineString" => Self::MultiLineString,
+            "Polygon" => Self::Polygon,
+            "MultiPolygon" => Self::MultiPolygon,
+            "GeometryCollection" => Self::GeometryCollection,
+            other => return Err(Error::GeometryUnknownType(other.to_string())),
+        })
+    }
+}
+
+// impl GeometryType {
+//     fn as_str(&self) -> &str {
+//         match self {
+//             GeometryType::Point => "Point",
+//             GeometryType::MultiPoint => "MultiPoint",
+//             GeometryType::LineString => "LineString",
+//             GeometryType::MultiLineString => "MultiLineString",
+//             GeometryType::Polygon => "Polygon",
+//             GeometryType::MultiPolygon => "MultiPolygon",
+//             GeometryType::GeometryCollection => "GeometryCollection",
+//         }
+//     }
+// }
+
 impl Geometry {
     /// Returns a new `Geometry` with the specified `value`. `bbox` and `foreign_members` will be
     /// set to `None`.
@@ -324,7 +367,8 @@ impl FromStr for Geometry {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self> {
-        Self::try_from(crate::GeoJson::from_str(s)?)
+        let mut de = serde_json::Deserializer::new(serde_json::de::StrRead::new(s));
+        Geometry::deserialize(&mut de).map_err(Into::into)
     }
 }
 
@@ -343,10 +387,171 @@ impl<'de> Deserialize<'de> for Geometry {
         D: Deserializer<'de>,
     {
         use serde::de::Error as SerdeError;
+        // let val = JsonObject::deserialize(deserializer)?;
+        // Geometry::from_json_object(val).map_err(|e| D::Error::custom(e.to_string()))
 
-        let val = JsonObject::deserialize(deserializer)?;
+        struct GeometryVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeometryVisitor {
+            type Value = Geometry;
 
-        Geometry::from_json_object(val).map_err(|e| D::Error::custom(e.to_string()))
+            fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+                write!(formatter, "a valid GeoJSON Geometry object")
+            }
+
+            fn visit_string<E>(self, _v: String) -> std::result::Result<Self::Value, E>
+            where
+                E: SerdeError,
+            {
+                todo!("visit string")
+            }
+
+            fn visit_borrowed_str<E>(self, _v: &'de str) -> std::result::Result<Self::Value, E>
+            where
+                E: SerdeError,
+            {
+                todo!("visit borrowed str")
+            }
+
+            fn visit_str<E>(self, _v: &str) -> std::result::Result<Self::Value, E>
+            where
+                E: SerdeError,
+            {
+                todo!("visit str")
+            }
+
+            fn visit_map<A>(self, mut map_access: A) -> std::result::Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                use crate::Position;
+
+                // Depending on the geometry type, the CoordinateField could have different dimensions
+                // This might not support mixed dimensionality
+                #[derive(Debug, Deserialize)]
+                #[serde(untagged)]
+                enum CoordinateField {
+                    ZeroDimensional(Position),          // Point
+                    OneDimensional(Vec<Position>),      // LineString, MultiPoint
+                    TwoDimensional(Vec<Vec<Position>>), // Polygon, MultiLineString
+                    ThreeDimensional(Vec<Vec<Vec<Position>>>), // MultiPolygon
+                                                        // ?????, // GeometryCollection
+                }
+
+                // impl<'de> Deserialize<'de> for CoordinateField {
+                //     fn deserialize<D>(de: D) -> std::result::Result<Self, D::Error> where D: Deserializer<'de> {
+                //         let dimensions = 0;
+                //         match Position::deserialize(de) {
+                //             Ok(p) => Ok(CoordinateField::ZeroDimensional(p)),
+                //             Err(e) => {
+                //                 match Vec::<Position>::deserialize(de) {
+                //                     Ok(p) => Ok(CoordinateField::OneDimensional(p)),
+                //                     Err(e) => {
+                //                         dbg!(e);
+                //                         todo!("impl deserialize for higher dimension coordinate field")
+                //                     }
+                //                 }
+                //             }
+                //         }
+                //     }
+                // }
+
+                fn build_geometry_value(
+                    geometry_type: GeometryType,
+                    coordinates: CoordinateField,
+                ) -> Result<Value> {
+                    match geometry_type {
+                        GeometryType::Point => {
+                            if let CoordinateField::ZeroDimensional(position) = coordinates {
+                                return Ok(Value::Point(position));
+                            }
+                        }
+                        GeometryType::MultiPoint => {
+                            if let CoordinateField::OneDimensional(position) = coordinates {
+                                return Ok(Value::MultiPoint(position));
+                            }
+                        }
+                        GeometryType::LineString => {
+                            if let CoordinateField::OneDimensional(position) = coordinates {
+                                return Ok(Value::LineString(position));
+                            }
+                        }
+                        GeometryType::MultiLineString => {
+                            if let CoordinateField::TwoDimensional(position) = coordinates {
+                                return Ok(Value::MultiLineString(position));
+                            }
+                        }
+                        GeometryType::Polygon => {
+                            if let CoordinateField::TwoDimensional(position) = coordinates {
+                                return Ok(Value::Polygon(position));
+                            }
+                        }
+                        GeometryType::MultiPolygon => {
+                            if let CoordinateField::ThreeDimensional(position) = coordinates {
+                                return Ok(Value::MultiPolygon(position));
+                            }
+                        }
+                        GeometryType::GeometryCollection => {
+                            if let CoordinateField::ThreeDimensional(position) = coordinates {
+                                todo!("build GeometryCollection from {position:?}")
+                            }
+                        }
+                    }
+                    todo!("handle dimensional mismatch")
+                }
+
+                let mut coordinate_field: Option<CoordinateField> = None;
+                let mut geometry_type: Option<GeometryType> = None;
+                let mut foreign_members: Option<JsonObject> = None;
+                let mut bbox: Option<Bbox> = None;
+
+                while let Some(next_key) = map_access.next_key::<String>()? {
+                    match next_key.as_str() {
+                        "coordinates" => {
+                            if coordinate_field.is_some() {
+                                todo!("handle existing coordinate field error");
+                            }
+                            coordinate_field = Some(map_access.next_value()?);
+                        }
+                        "type" => {
+                            if geometry_type.is_some() {
+                                todo!("handle existing geometry field error");
+                            }
+                            let geometry_type_string: String = map_access.next_value()?;
+                            let gt = GeometryType::from_str(geometry_type_string.as_str())
+                                .map_err(A::Error::custom)?;
+                            geometry_type = Some(gt);
+                        }
+                        "bbox" => {
+                            // REVIEW: still need to test this.
+                            bbox = Some(map_access.next_value()?);
+                        }
+                        _ => {
+                            if let Some(ref mut foreign_members) = foreign_members {
+                                foreign_members.insert(next_key, map_access.next_value()?);
+                            } else {
+                                let mut fm = JsonObject::new();
+                                fm.insert(next_key, map_access.next_value()?);
+                                foreign_members = Some(fm);
+                            }
+                        }
+                    }
+                }
+
+                let (Some(geometry_type),Some(coordinate_field)) = (geometry_type, coordinate_field) else {
+                    todo!("missing geometry type or coordinate field");
+                };
+                let value: Value = build_geometry_value(geometry_type, coordinate_field)
+                    .map_err(A::Error::custom)?;
+
+                Ok(Geometry {
+                    value,
+                    bbox,
+                    foreign_members,
+                })
+            }
+        }
+
+        deserializer.deserialize_map(GeometryVisitor)
     }
 }
 
@@ -361,7 +566,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{Error, GeoJson, Geometry, JsonObject, Position, Value};
+    use super::*;
+    use crate::{GeoJson, Position};
     use serde_json::json;
     use std::str::FromStr;
 
@@ -534,11 +740,43 @@ mod tests {
 
         let actual_failure = Geometry::from_str(&feature_json).unwrap_err();
         match actual_failure {
-            Error::ExpectedType { actual, expected } => {
-                assert_eq!(actual, "Feature");
-                assert_eq!(expected, "Geometry");
+            Error::MalformedJson(e) => {
+                e.to_string().contains("Feature");
             }
             e => panic!("unexpected error: {}", e),
         };
+    }
+
+    mod deserialize {
+        use super::*;
+        use crate::Geometry;
+        use crate::Value;
+
+        #[test]
+        fn point() {
+            let json = json!({
+                "type": "Point",
+                "coordinates": [1.0, 2.0]
+            })
+            .to_string();
+
+            let geom = Geometry::from_str(&json).unwrap();
+            let expected = Value::Point(Position::from([1.0, 2.0]));
+            assert_eq!(geom.value, expected);
+        }
+
+        #[test]
+        fn linestring() {
+            let json = json!({
+                "type": "LineString",
+                "coordinates": [[1.0, 2.0], [3.0, 4.0]]
+            })
+            .to_string();
+
+            let geom = Geometry::from_str(&json).unwrap();
+            let expected =
+                Value::LineString(vec![Position::from([1.0, 2.0]), Position::from([3.0, 4.0])]);
+            assert_eq!(geom.value, expected);
+        }
     }
 }


### PR DESCRIPTION
This is an addendum to #222, I'm not sure it's going to work out, but I wanted to share progress in case someone smarter than me wants to weigh in...

Context: In main today, we represent coordinates (`Positions`) as a Vec of floats. This entails a heap allocation per point, which is slow. #222 changes Positions to be backed by a tiny_vec, which can be stack allocated up to a certain size.

However, even with #222, we stll use serde_json to parse the input - so those Vec's are created before converting them to the tiny_vec backed representation.

This branch represents my various experiments to avoid allocating Vec's to parse points. I will be the first to admit that it's currently very gnarly. I am not very familiar with the innards of serde (I'm getting a little better through this work!).

Unlike #222, this branch is very from being mergable. But as a POC I did want to share some modest wins:

Note that this bench is baselined against the changes in #222, not main:
```
$ cargo bench --bench="*" -- --baseline="tiny-vec"
 
parse (countries.geojson)
                        time:   [1.8220 ms 1.8453 ms 1.8728 ms]
                        change: [-2.6785% -1.9295% -1.1463%] (p = 0.00 < 0.05)
                        Performance has improved.

FeatureReader::features (countries.geojson)
                        time:   [5.2148 ms 5.2285 ms 5.2429 ms]
                        change: [-10.682% -10.259% -9.8336%] (p = 0.00 < 0.05)
                        Performance has improved.

# 👀 this input is small, so maybe not very representative, but still -
# I'm curious why the wins are so huge here while so relatively modest elsewhere.
# I'd guess that in the other benches, much of the remaining time is spent parsing floats.
parse (geometry_collection.geojson)
                        time:   [489.36 ns 490.73 ns 492.07 ns]
                        change: [-96.840% -96.814% -96.794%] (p = 0.00 < 0.05)
                        Performance has improved.

     Running benches/serialize.rs (target/release/deps/serialize-52a1ff0867a899e5)
serialize geojson::FeatureCollection struct (countries.geojson)
                        time:   [2.8810 ms 2.8919 ms 2.9034 ms]
                        change: [+1.2959% +1.7045% +2.1246%] (p = 0.00 < 0.05)
                        Performance has regressed.

     Running benches/to_geo_types.rs (target/release/deps/to_geo_types-9c7e7ca989cc32d0)
quick_collection        time:   [66.437 µs 66.623 µs 66.819 µs]
                        change: [-0.1052% +0.4353% +0.9697%] (p = 0.11 > 0.05)
                        No change in performance detected.
```

🚨 This WIP currently breaks lots of things - like custom struct serialize/deserialization. If I proceed with this, I'll fix that before marking it "ready for review".
