### PR TITLE
Reject zero- and one-dimensional positions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## UNRELEASED
 
+* Modified conversion from JSON to reject zero- and one-dimensional positions.
+  * PR: <https://github.com/georust/geojson/pull/225>
+
 ## 0.24.0
 
 * Added `geojson::{ser, de}` helpers to convert your custom struct to and from GeoJSON. 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -55,6 +55,8 @@ pub enum Error {
     ExpectedArrayValue(String),
     #[error("Expected an owned Object, but got `{0}`")]
     ExpectedObjectValue(Value),
+    #[error("A position must contain two or more elements, but got `{0}`")]
+    PositionTooShort(usize),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -109,7 +109,7 @@ impl<'a> From<&'a Value> for JsonObject {
                 Value::GeometryCollection(..) => "geometries",
                 _ => "coordinates",
             }),
-            ::serde_json::to_value(&value).unwrap(),
+            ::serde_json::to_value(value).unwrap(),
         );
         map
     }
@@ -529,5 +529,20 @@ mod tests {
             }
             e => panic!("unexpected error: {}", e),
         };
+    }
+
+    #[test]
+    fn test_reject_too_few_coordinates() {
+        let err = Geometry::from_str(r#"{"type": "Point", "coordinates": []}"#).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "A position must contain two or more elements, but got `0`"
+        );
+
+        let err = Geometry::from_str(r#"{"type": "Point", "coordinates": [23.42]}"#).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "A position must contain two or more elements, but got `1`"
+        );
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -210,6 +210,9 @@ pub fn get_features(object: &mut JsonObject) -> Result<Vec<Feature>> {
 
 fn json_to_position(json: &JsonValue) -> Result<Position> {
     let coords_array = expect_array(json)?;
+    if coords_array.len() < 2 {
+        return Err(Error::PositionTooShort(coords_array.len()));
+    }
     let mut coords = Vec::with_capacity(coords_array.len());
     for position in coords_array {
         coords.push(expect_f64(position)?);


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This are invalid as per the specification and can lead to unexpected panics later on when these instances of `geojson::Geometry` are converted into `geo_types::Geometry` for example.

Closes #224 