### PR TITLE
Add a conversion from Vec<Feature> to GeoJson

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Added conversion from `Vec<Feature>` to `GeoJson`.
+
 ## 0.24.1
 
 * Modified conversion from JSON to reject zero- and one-dimensional positions.

--- a/src/geojson.rs
+++ b/src/geojson.rs
@@ -97,6 +97,12 @@ impl From<FeatureCollection> for GeoJson {
     }
 }
 
+impl From<Vec<Feature>> for GeoJson {
+    fn from(features: Vec<Feature>) -> GeoJson {
+        GeoJson::from(features.into_iter().collect::<FeatureCollection>())
+    }
+}
+
 impl TryFrom<GeoJson> for Geometry {
     type Error = Error;
     fn try_from(value: GeoJson) -> Result<Self> {
@@ -392,7 +398,7 @@ impl fmt::Display for FeatureCollection {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Error, Feature, GeoJson, Geometry, Value};
+    use crate::{Error, Feature, FeatureCollection, GeoJson, Geometry, Value};
     use serde_json::json;
     use std::convert::TryInto;
     use std::str::FromStr;
@@ -446,6 +452,39 @@ mod tests {
                 geometry: Some(Geometry::new(Value::Point(vec![102.0, 0.5]))),
                 id: None,
                 properties: None,
+                foreign_members: None,
+            })
+        );
+    }
+
+    #[test]
+    fn test_geojson_from_features() {
+        let features: Vec<Feature> = vec![
+            Value::Point(vec![0., 0., 0.]).into(),
+            Value::Point(vec![1., 1., 1.]).into(),
+        ];
+
+        let geojson: GeoJson = features.into();
+        assert_eq!(
+            geojson,
+            GeoJson::FeatureCollection(FeatureCollection {
+                features: vec![
+                    Feature {
+                        bbox: None,
+                        geometry: Some(Geometry::new(Value::Point(vec![0., 0., 0.]))),
+                        id: None,
+                        properties: None,
+                        foreign_members: None,
+                    },
+                    Feature {
+                        bbox: None,
+                        geometry: Some(Geometry::new(Value::Point(vec![1., 1., 1.]))),
+                        id: None,
+                        properties: None,
+                        foreign_members: None,
+                    },
+                ],
+                bbox: None,
                 foreign_members: None,
             })
         );


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

As discussed in Discord, this is more convenient than `let gj = geojson::GeoJson::from(features.into_iter().collect::<geojson::FeatureCollection>());` or `let gj:GeoJson = FeatureCollection::from_iter(vec_of_geojson_features.into_iter()).into();` or similar