### PR TITLE
Add support for foreign members to FeatureWriter.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Add support for foreign members to `FeatureWriter`.
 * Added conversion from `Vec<Feature>` to `GeoJson`.
 
 ## 0.24.1

--- a/src/feature_writer.rs
+++ b/src/feature_writer.rs
@@ -7,8 +7,8 @@ use std::io::Write;
 #[derive(PartialEq)]
 enum State {
     New,
-    Started,
-    StartedWithForeignMembers,
+    WritingFeatures,
+    WritingForeignMembers,
     Finished,
 }
 
@@ -45,13 +45,13 @@ impl<W: Write> FeatureWriter<W> {
             }
             State::New => {
                 self.write_prefix()?;
-                self.state = State::Started;
+                self.state = State::WritingFeatures;
             }
-            State::Started => {
+            State::WritingFeatures => {
                 self.write_str(",")?;
             }
-            State::StartedWithForeignMembers => {
-                self.state = State::Started;
+            State::WritingForeignMembers => {
+                self.state = State::WritingFeatures;
             }
         }
         serde_json::to_writer(&mut self.writer, feature)?;
@@ -165,13 +165,13 @@ impl<W: Write> FeatureWriter<W> {
             }
             State::New => {
                 self.write_prefix()?;
-                self.state = State::Started;
+                self.state = State::WritingFeatures;
             }
-            State::Started => {
+            State::WritingFeatures => {
                 self.write_str(",")?;
             }
-            State::StartedWithForeignMembers => {
-                self.state = State::Started;
+            State::WritingForeignMembers => {
+                self.state = State::WritingFeatures;
             }
         }
         to_feature_writer(&mut self.writer, value)
@@ -196,15 +196,15 @@ impl<W: Write> FeatureWriter<W> {
                 }
 
                 self.write_str(r#" "features": ["#)?;
-                self.state = State::StartedWithForeignMembers;
+                self.state = State::WritingForeignMembers;
                 Ok(())
             }
-            State::Started => {
+            State::WritingFeatures => {
                 return Err(Error::InvalidWriterState(
                     "must write foreign members before any features",
                 ))
             }
-            State::StartedWithForeignMembers => {
+            State::WritingForeignMembers => {
                 return Err(Error::InvalidWriterState(
                     "can only write foreign members once",
                 ))
@@ -228,7 +228,7 @@ impl<W: Write> FeatureWriter<W> {
                 self.write_prefix()?;
                 self.write_suffix()?;
             }
-            State::Started | State::StartedWithForeignMembers => {
+            State::WritingFeatures | State::WritingForeignMembers => {
                 self.state = State::Finished;
                 self.write_suffix()?;
             }

--- a/src/feature_writer.rs
+++ b/src/feature_writer.rs
@@ -429,7 +429,7 @@ mod tests {
             let mut writer = FeatureWriter::from_writer(&mut buffer);
 
             writer
-                .write_foreign_member("extra", &json!("string"))
+                .write_foreign_member("extra", "string")
                 .unwrap();
             writer
                 .write_foreign_member("list", &json!([1, 2, 3]))

--- a/src/feature_writer.rs
+++ b/src/feature_writer.rs
@@ -181,7 +181,11 @@ impl<W: Write> FeatureWriter<W> {
 
     /// Write a [foreign member](https://datatracker.ietf.org/doc/html/rfc7946#section-6) to the
     /// output stream. This must be done before appending any features.
-    pub fn write_foreign_member<T: ?Sized + Serialize>(&mut self, key: &str, value: &T) -> Result<()> {
+    pub fn write_foreign_member<T: ?Sized + Serialize>(
+        &mut self,
+        key: &str,
+        value: &T,
+    ) -> Result<()> {
         match self.state {
             State::Finished => {
                 return Err(Error::InvalidWriterState(
@@ -428,12 +432,8 @@ mod tests {
         {
             let mut writer = FeatureWriter::from_writer(&mut buffer);
 
-            writer
-                .write_foreign_member("extra", "string")
-                .unwrap();
-            writer
-                .write_foreign_member("list", &[1, 2, 3])
-                .unwrap();
+            writer.write_foreign_member("extra", "string").unwrap();
+            writer.write_foreign_member("list", &[1, 2, 3]).unwrap();
             writer
                 .write_foreign_member("nested", &json!({"foo": "bar"}))
                 .unwrap();

--- a/src/feature_writer.rs
+++ b/src/feature_writer.rs
@@ -181,7 +181,7 @@ impl<W: Write> FeatureWriter<W> {
 
     /// Write a [foreign member](https://datatracker.ietf.org/doc/html/rfc7946#section-6) to the
     /// output stream. This must be done before appending any features.
-    pub fn write_foreign_member(&mut self, key: &str, value: &JsonValue) -> Result<()> {
+    pub fn write_foreign_member<T: ?Sized + Serialize>(&mut self, key: &str, value: &T) -> Result<()> {
         match self.state {
             State::Finished => {
                 return Err(Error::InvalidWriterState(

--- a/src/feature_writer.rs
+++ b/src/feature_writer.rs
@@ -432,7 +432,7 @@ mod tests {
                 .write_foreign_member("extra", "string")
                 .unwrap();
             writer
-                .write_foreign_member("list", &json!([1, 2, 3]))
+                .write_foreign_member("list", &[1, 2, 3])
                 .unwrap();
             writer
                 .write_foreign_member("nested", &json!({"foo": "bar"}))


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.