### PR TITLE
Implement `Serialize` without going through JsonObject

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Added conversion from `Vec<Feature>` to `GeoJson`.
+* Changed `Serialize` impls to avoid creating intermediate `JsonObject`s.
 
 ## 0.24.1
 

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -54,12 +54,17 @@ impl FromStr for Feature {
 
 impl<'a> From<&'a Feature> for JsonObject {
     fn from(feature: &'a Feature) -> JsonObject {
+        // The unwrap() should never panic, because Feature contains only JSON-serializable types
         match serde_json::to_value(feature).unwrap() {
             serde_json::Value::Object(obj) => obj,
-            value => panic!(
-                "serializing Feature should result in an Object, but got something {:?}",
-                value
-            ),
+            value => {
+                // Panic should never happen, because `impl Serialize for Feature` always produces an
+                // Object
+                panic!(
+                    "serializing Feature should result in an Object, but got something {:?}",
+                    value
+                )
+            }
         }
     }
 }

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -162,11 +162,7 @@ impl Serialize for Feature {
         let mut map = serializer.serialize_map(None)?;
         map.serialize_entry("type", "Feature")?;
         map.serialize_entry("geometry", &self.geometry)?;
-        if let Some(ref properties) = self.properties {
-            map.serialize_entry("properties", properties)?;
-        } else {
-            map.serialize_entry("properties", &JsonObject::new())?;
-        }
+        map.serialize_entry("properties", &self.properties)?;
         if let Some(ref bbox) = self.bbox {
             map.serialize_entry("bbox", bbox)?;
         }
@@ -427,6 +423,29 @@ mod tests {
             bbox: None,
             id: None,
             foreign_members: Some(foreign_members),
+        };
+        // Test encode
+        let json_string = encode(&feature);
+        assert_eq!(json_string, feature_json_str);
+
+        // Test decode
+        let decoded_feature = match decode(feature_json_str.into()) {
+            GeoJson::Feature(f) => f,
+            _ => unreachable!(),
+        };
+        assert_eq!(decoded_feature, feature);
+    }
+
+    #[test]
+    fn encode_decode_feature_with_null_properties() {
+        let feature_json_str = r#"{"type":"Feature","geometry":{"type":"Point","coordinates":[1.1,2.1]},"properties":null}"#;
+
+        let feature = crate::Feature {
+            geometry: Some(Value::Point(vec![1.1, 2.1]).into()),
+            properties: None,
+            bbox: None,
+            id: None,
+            foreign_members: None,
         };
         // Test encode
         let json_string = encode(&feature);

--- a/src/feature_collection.rs
+++ b/src/feature_collection.rs
@@ -94,12 +94,14 @@ impl<'a> IntoIterator for &'a FeatureCollection {
 
 impl<'a> From<&'a FeatureCollection> for JsonObject {
     fn from(fc: &'a FeatureCollection) -> JsonObject {
+        // The unwrap() should never panic, because FeatureCollection contains only JSON-serializable types
         match serde_json::to_value(fc).unwrap() {
             serde_json::Value::Object(obj) => obj,
-            value => panic!(
-                "serializing FeatureCollection should result in an Object, but got something {:?}",
-                value
-            ),
+            value => {
+                // Panic should never happen, because `impl Serialize for FeatureCollection` always produces an
+                // Object
+                panic!("serializing FeatureCollection should result in an Object, but got something {:?}", value)
+            }
         }
     }
 }

--- a/src/feature_collection.rs
+++ b/src/feature_collection.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use serde::ser::SerializeMap;
 use std::convert::TryFrom;
 use std::iter::FromIterator;
 use std::str::FromStr;
@@ -20,7 +21,6 @@ use crate::errors::{Error, Result};
 use crate::{util, Bbox, Feature};
 use crate::{JsonObject, JsonValue};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use serde_json::json;
 
 /// Feature Collection Objects
 ///
@@ -44,7 +44,7 @@ use serde_json::json;
 ///
 /// assert_eq!(
 ///     serialized,
-///     "{\"features\":[],\"type\":\"FeatureCollection\"}"
+///     "{\"type\":\"FeatureCollection\",\"features\":[]}"
 /// );
 /// ```
 ///
@@ -94,24 +94,13 @@ impl<'a> IntoIterator for &'a FeatureCollection {
 
 impl<'a> From<&'a FeatureCollection> for JsonObject {
     fn from(fc: &'a FeatureCollection) -> JsonObject {
-        let mut map = JsonObject::new();
-        map.insert(String::from("type"), json!("FeatureCollection"));
-        map.insert(
-            String::from("features"),
-            serde_json::to_value(&fc.features).unwrap(),
-        );
-
-        if let Some(ref bbox) = fc.bbox {
-            map.insert(String::from("bbox"), serde_json::to_value(bbox).unwrap());
+        match serde_json::to_value(fc).unwrap() {
+            serde_json::Value::Object(obj) => obj,
+            value => panic!(
+                "serializing FeatureCollection should result in an Object, but got something {:?}",
+                value
+            ),
         }
-
-        if let Some(ref foreign_members) = fc.foreign_members {
-            for (key, value) in foreign_members {
-                map.insert(key.to_owned(), value.to_owned());
-            }
-        }
-
-        map
     }
 }
 
@@ -168,7 +157,21 @@ impl Serialize for FeatureCollection {
     where
         S: Serializer,
     {
-        JsonObject::from(self).serialize(serializer)
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "FeatureCollection")?;
+        map.serialize_entry("features", &self.features)?;
+
+        if let Some(ref bbox) = self.bbox {
+            map.serialize_entry("bbox", bbox)?;
+        }
+
+        if let Some(ref foreign_members) = self.foreign_members {
+            for (key, value) in foreign_members {
+                map.serialize_entry(key, value)?;
+            }
+        }
+
+        map.end()
     }
 }
 

--- a/src/geojson.rs
+++ b/src/geojson.rs
@@ -301,7 +301,11 @@ impl Serialize for GeoJson {
     where
         S: Serializer,
     {
-        JsonObject::from(self).serialize(serializer)
+        match self {
+            GeoJson::Geometry(ref geometry) => geometry.serialize(serializer),
+            GeoJson::Feature(ref feature) => feature.serialize(serializer),
+            GeoJson::FeatureCollection(ref fc) => fc.serialize(serializer),
+        }
     }
 }
 

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -102,6 +102,7 @@ impl<'a> From<&'a Value> for JsonObject {
         let mut map = JsonObject::new();
         map.insert(
             String::from("type"),
+            // The unwrap() should never panic, because &str always serializes to JSON
             ::serde_json::to_value(value.type_name()).unwrap(),
         );
         map.insert(
@@ -109,6 +110,7 @@ impl<'a> From<&'a Value> for JsonObject {
                 Value::GeometryCollection(..) => "geometries",
                 _ => "coordinates",
             }),
+            // The unwrap() should never panic, because Value contains only JSON-serializable types
             ::serde_json::to_value(value).unwrap(),
         );
         map

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -18,7 +18,7 @@ use std::{convert::TryFrom, fmt};
 use crate::errors::{Error, Result};
 use crate::{util, Bbox, LineStringType, PointType, PolygonType};
 use crate::{JsonObject, JsonValue};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};
 
 /// The underlying value for a `Geometry`.
 ///
@@ -123,6 +123,21 @@ impl Value {
     pub fn from_json_value(value: JsonValue) -> Result<Self> {
         Self::try_from(value)
     }
+
+    fn serialize_to_map<SM: SerializeMap>(
+        &self,
+        map: &mut SM,
+    ) -> std::result::Result<(), SM::Error> {
+        map.serialize_entry("type", self.type_name())?;
+        map.serialize_entry(
+            match self {
+                Value::GeometryCollection(..) => "geometries",
+                _ => "coordinates",
+            },
+            self,
+        )?;
+        Ok(())
+    }
 }
 
 impl TryFrom<JsonObject> for Value {
@@ -155,16 +170,7 @@ impl fmt::Display for Value {
 
 impl<'a> From<&'a Value> for JsonValue {
     fn from(value: &'a Value) -> JsonValue {
-        match *value {
-            Value::Point(ref x) => ::serde_json::to_value(x),
-            Value::MultiPoint(ref x) => ::serde_json::to_value(x),
-            Value::LineString(ref x) => ::serde_json::to_value(x),
-            Value::MultiLineString(ref x) => ::serde_json::to_value(x),
-            Value::Polygon(ref x) => ::serde_json::to_value(x),
-            Value::MultiPolygon(ref x) => ::serde_json::to_value(x),
-            Value::GeometryCollection(ref x) => ::serde_json::to_value(x),
-        }
-        .unwrap()
+        ::serde_json::to_value(value).unwrap()
     }
 }
 
@@ -173,7 +179,15 @@ impl Serialize for Value {
     where
         S: Serializer,
     {
-        JsonValue::from(self).serialize(serializer)
+        match self {
+            Value::Point(x) => x.serialize(serializer),
+            Value::MultiPoint(x) => x.serialize(serializer),
+            Value::LineString(x) => x.serialize(serializer),
+            Value::MultiLineString(x) => x.serialize(serializer),
+            Value::Polygon(x) => x.serialize(serializer),
+            Value::MultiPolygon(x) => x.serialize(serializer),
+            Value::GeometryCollection(x) => x.serialize(serializer),
+        }
     }
 }
 
@@ -208,7 +222,7 @@ impl Serialize for Value {
 /// let geojson_string = geometry.to_string();
 ///
 /// assert_eq!(
-///     "{\"coordinates\":[7.428959,1.513394],\"type\":\"Point\"}",
+///     "{\"type\":\"Point\",\"coordinates\":[7.428959,1.513394]}",
 ///     geojson_string,
 /// );
 /// ```
@@ -291,6 +305,23 @@ impl Geometry {
     pub fn from_json_value(value: JsonValue) -> Result<Self> {
         Self::try_from(value)
     }
+
+    fn serialize_to_map<SM: SerializeMap>(
+        &self,
+        map: &mut SM,
+    ) -> std::result::Result<(), SM::Error> {
+        self.value.serialize_to_map(map)?;
+        if let Some(ref bbox) = self.bbox {
+            map.serialize_entry("bbox", bbox)?;
+        }
+
+        if let Some(ref foreign_members) = self.foreign_members {
+            for (key, value) in foreign_members {
+                map.serialize_entry(key, value)?
+            }
+        }
+        Ok(())
+    }
 }
 
 impl TryFrom<JsonObject> for Geometry {
@@ -333,7 +364,9 @@ impl Serialize for Geometry {
     where
         S: Serializer,
     {
-        JsonObject::from(self).serialize(serializer)
+        let mut map = serializer.serialize_map(None)?;
+        self.serialize_to_map(&mut map)?;
+        map.end()
     }
 }
 
@@ -374,7 +407,7 @@ mod tests {
 
     #[test]
     fn encode_decode_geometry() {
-        let geometry_json_str = "{\"coordinates\":[1.1,2.1],\"type\":\"Point\"}";
+        let geometry_json_str = "{\"type\":\"Point\",\"coordinates\":[1.1,2.1]}";
         let geometry = Geometry {
             value: Value::Point(vec![1.1, 2.1]),
             bbox: None,
@@ -422,8 +455,8 @@ mod tests {
         let v = Value::LineString(vec![vec![0.0, 0.1], vec![0.1, 0.2], vec![0.2, 0.3]]);
         let geometry = Geometry::new(v);
         assert_eq!(
-            "{\"coordinates\":[[0.0,0.1],[0.1,0.2],[0.2,0.3]],\"type\":\"LineString\"}",
-            geometry.to_string()
+            geometry.to_string(),
+            "{\"type\":\"LineString\",\"coordinates\":[[0.0,0.1],[0.1,0.2],[0.2,0.3]]}"
         );
     }
 
@@ -439,7 +472,7 @@ mod tests {
     #[test]
     fn encode_decode_geometry_with_foreign_member() {
         let geometry_json_str =
-            "{\"coordinates\":[1.1,2.1],\"other_member\":true,\"type\":\"Point\"}";
+            "{\"type\":\"Point\",\"coordinates\":[1.1,2.1],\"other_member\":true}";
         let mut foreign_members = JsonObject::new();
         foreign_members.insert(
             String::from("other_member"),
@@ -482,7 +515,7 @@ mod tests {
             foreign_members: None,
         };
 
-        let geometry_collection_string = "{\"geometries\":[{\"coordinates\":[100.0,0.0],\"type\":\"Point\"},{\"coordinates\":[[101.0,0.0],[102.0,1.0]],\"type\":\"LineString\"}],\"type\":\"GeometryCollection\"}";
+        let geometry_collection_string = "{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"Point\",\"coordinates\":[100.0,0.0]},{\"type\":\"LineString\",\"coordinates\":[[101.0,0.0],[102.0,1.0]]}]}";
         // Test encode
         let json_string = encode(&geometry_collection);
         assert_eq!(json_string, geometry_collection_string);


### PR DESCRIPTION
As described in <https://github.com/georust/geojson/issues/152>, serialization by constructing a JsonObject has to essentially clone all data, which requires extra allocations.

After this change, we pass data directly to the `Serializer`.

`JsonObject` and `JsonValue` conversion impls were rewritten to delegate to `Serialize`. This requires some unfortunate `panic`s where we expect `Serialize` to produce a JSON object, but I think it's better than duplicating the serialization logic.

Benchmark results (compared vs `4cfbf3a`):

```
serialize geojson::FeatureCollection struct (countries.geojson)
                        time:   [990.01 µs 1.0025 ms 1.0172 ms]
                        change: [-74.789% -74.267% -73.763%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

serialize custom struct (countries.geojson)
                        time:   [2.1757 ms 2.2237 ms 2.2718 ms]
                        change: [-40.176% -38.891% -37.671%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

serialize custom struct to geo-types (countries.geojson)
                        time:   [2.3386 ms 2.3570 ms 2.3776 ms]
                        change: [-42.699% -41.782% -40.960%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  7 (7.00%) high mild
  3 (3.00%) high severe
```

Custom structs still have to go through JsonObject, so there isn't as much improvement there.

Expected JSON outputs in tests had changed, because now we produce JSON object keys in order of the `serialize_entry` calls, instead of `serde_json::Map` order.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

