### PR TITLE
feat: Generic Precision

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 * Add support for foreign members to `FeatureWriter`.
 * Added conversion from `Vec<Feature>` to `GeoJson`.
 * Changed `Serialize` impls to avoid creating intermediate `JsonObject`s.
+* Add support for generic precision
 
 ## 0.24.1
 

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -21,7 +21,7 @@ fn parse_feature_collection_benchmark(c: &mut Criterion) {
     c.bench_function("FeatureReader::features (countries.geojson)", |b| {
         b.iter(|| {
             let feature_reader =
-                geojson::FeatureReader::from_reader(BufReader::new(geojson_str.as_bytes()));
+                geojson::FeatureReader::<_, f64>::from_reader(BufReader::new(geojson_str.as_bytes()));
             let mut count = 0;
             for feature in feature_reader.features() {
                 let feature = feature.unwrap();
@@ -41,7 +41,7 @@ fn parse_feature_collection_benchmark(c: &mut Criterion) {
                 name: String,
             }
             let feature_reader =
-                geojson::FeatureReader::from_reader(BufReader::new(geojson_str.as_bytes()));
+                geojson::FeatureReader::<_, f64>::from_reader(BufReader::new(geojson_str.as_bytes()));
 
             let mut count = 0;
             for feature in feature_reader.deserialize::<Country>().unwrap() {
@@ -66,7 +66,7 @@ fn parse_feature_collection_benchmark(c: &mut Criterion) {
                     name: String,
                 }
                 let feature_reader =
-                    geojson::FeatureReader::from_reader(BufReader::new(geojson_str.as_bytes()));
+                    geojson::FeatureReader::<_, f64>::from_reader(BufReader::new(geojson_str.as_bytes()));
 
                 let mut count = 0;
                 for feature in feature_reader.deserialize::<Country>().unwrap() {

--- a/examples/deserialize.rs
+++ b/examples/deserialize.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Write the structs back to GeoJSON
     let file_writer = BufWriter::new(File::create("example-output-countries.geojson")?);
-    geojson::ser::to_feature_collection_writer(file_writer, &countries)?;
+    geojson::ser::to_feature_collection_writer::<_, _, f64>(file_writer, &countries)?;
 
     Ok(())
 }

--- a/examples/deserialize_to_geo_types.rs
+++ b/examples/deserialize_to_geo_types.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Write the structs back to GeoJSON
     let file_writer = BufWriter::new(File::create("example-output-countries.geojson")?);
-    geojson::ser::to_feature_collection_writer(file_writer, &countries)?;
+    geojson::ser::to_feature_collection_writer::<_, _, f64>(file_writer, &countries)?;
 
     Ok(())
 }

--- a/examples/stream_reader_writer.rs
+++ b/examples/stream_reader_writer.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let reader = {
         let file_reader = BufReader::new(File::open("tests/fixtures/countries.geojson")?);
-        FeatureReader::from_reader(file_reader)
+        FeatureReader::<_, f64>::from_reader(file_reader)
     };
 
     let mut writer = {

--- a/src/conversion/from_geo_types.rs
+++ b/src/conversion/from_geo_types.rs
@@ -1,4 +1,5 @@
 use geo_types::{self, CoordFloat};
+use serde::Serialize;
 
 use crate::{geometry, Feature, FeatureCollection};
 
@@ -6,9 +7,9 @@ use crate::{LineStringType, PointType, PolygonType};
 use std::convert::From;
 
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
-impl<'a, T> From<&'a geo_types::Point<T>> for geometry::Value
+impl<'a, T> From<&'a geo_types::Point<T>> for geometry::Value<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + Serialize,
 {
     fn from(point: &geo_types::Point<T>) -> Self {
         let coords = create_point_type(point);
@@ -18,9 +19,9 @@ where
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
-impl<'a, T> From<&'a geo_types::MultiPoint<T>> for geometry::Value
+impl<'a, T> From<&'a geo_types::MultiPoint<T>> for geometry::Value<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + Serialize,
 {
     fn from(multi_point: &geo_types::MultiPoint<T>) -> Self {
         let coords = multi_point
@@ -34,9 +35,9 @@ where
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
-impl<'a, T> From<&'a geo_types::LineString<T>> for geometry::Value
+impl<'a, T> From<&'a geo_types::LineString<T>> for geometry::Value<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + Serialize,
 {
     fn from(line_string: &geo_types::LineString<T>) -> Self {
         let coords = create_line_string_type(line_string);
@@ -46,9 +47,9 @@ where
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
-impl<'a, T> From<&'a geo_types::Line<T>> for geometry::Value
+impl<'a, T> From<&'a geo_types::Line<T>> for geometry::Value<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + Serialize,
 {
     fn from(line: &geo_types::Line<T>) -> Self {
         let coords = create_from_line_type(line);
@@ -58,9 +59,9 @@ where
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
-impl<'a, T> From<&'a geo_types::Triangle<T>> for geometry::Value
+impl<'a, T> From<&'a geo_types::Triangle<T>> for geometry::Value<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + Serialize,
 {
     fn from(triangle: &geo_types::Triangle<T>) -> Self {
         let coords = create_from_triangle_type(triangle);
@@ -70,9 +71,9 @@ where
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
-impl<'a, T> From<&'a geo_types::Rect<T>> for geometry::Value
+impl<'a, T> From<&'a geo_types::Rect<T>> for geometry::Value<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + Serialize,
 {
     fn from(rect: &geo_types::Rect<T>) -> Self {
         let coords = create_from_rect_type(rect);
@@ -82,9 +83,9 @@ where
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
-impl<'a, T> From<&'a geo_types::MultiLineString<T>> for geometry::Value
+impl<'a, T> From<&'a geo_types::MultiLineString<T>> for geometry::Value<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + Serialize,
 {
     fn from(multi_line_string: &geo_types::MultiLineString<T>) -> Self {
         let coords = create_multi_line_string_type(multi_line_string);
@@ -94,9 +95,9 @@ where
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
-impl<'a, T> From<&'a geo_types::Polygon<T>> for geometry::Value
+impl<'a, T> From<&'a geo_types::Polygon<T>> for geometry::Value<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + Serialize,
 {
     fn from(polygon: &geo_types::Polygon<T>) -> Self {
         let coords = create_polygon_type(polygon);
@@ -106,9 +107,9 @@ where
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
-impl<'a, T> From<&'a geo_types::MultiPolygon<T>> for geometry::Value
+impl<'a, T> From<&'a geo_types::MultiPolygon<T>> for geometry::Value<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + Serialize,
 {
     fn from(multi_polygon: &geo_types::MultiPolygon<T>) -> Self {
         let coords = create_multi_polygon_type(multi_polygon);
@@ -118,9 +119,9 @@ where
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
-impl<'a, T> From<&'a geo_types::GeometryCollection<T>> for geometry::Value
+impl<'a, T> From<&'a geo_types::GeometryCollection<T>> for geometry::Value<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + Serialize,
 {
     fn from(geometry_collection: &geo_types::GeometryCollection<T>) -> Self {
         let values = geometry_collection
@@ -134,12 +135,12 @@ where
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
-impl<'a, T> From<&'a geo_types::GeometryCollection<T>> for FeatureCollection
+impl<'a, T> From<&'a geo_types::GeometryCollection<T>> for FeatureCollection<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + Serialize,
 {
     fn from(geometry_collection: &geo_types::GeometryCollection<T>) -> Self {
-        let values: Vec<Feature> = geometry_collection
+        let values: Vec<Feature<T>> = geometry_collection
             .0
             .iter()
             .map(|geometry| geometry::Geometry::new(geometry::Value::from(geometry)).into())
@@ -154,9 +155,9 @@ where
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
-impl<'a, T> From<&'a geo_types::Geometry<T>> for geometry::Value
+impl<'a, T> From<&'a geo_types::Geometry<T>> for geometry::Value<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + Serialize,
 {
     /// Convert from `geo_types::Geometry` enums
     fn from(geometry: &'a geo_types::Geometry<T>) -> Self {
@@ -179,19 +180,19 @@ where
     }
 }
 
-fn create_point_type<T>(point: &geo_types::Point<T>) -> PointType
+fn create_point_type<T>(point: &geo_types::Point<T>) -> PointType<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + Serialize,
 {
-    let x: f64 = point.x().to_f64().unwrap();
-    let y: f64 = point.y().to_f64().unwrap();
+    let x = point.x();
+    let y = point.y();
 
     vec![x, y]
 }
 
-fn create_line_string_type<T>(line_string: &geo_types::LineString<T>) -> LineStringType
+fn create_line_string_type<T>(line_string: &geo_types::LineString<T>) -> LineStringType<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + Serialize,
 {
     line_string
         .points_iter()
@@ -199,9 +200,9 @@ where
         .collect()
 }
 
-fn create_from_line_type<T>(line_string: &geo_types::Line<T>) -> LineStringType
+fn create_from_line_type<T>(line_string: &geo_types::Line<T>) -> LineStringType<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + Serialize,
 {
     vec![
         create_point_type(&line_string.start_point()),
@@ -209,25 +210,25 @@ where
     ]
 }
 
-fn create_from_triangle_type<T>(triangle: &geo_types::Triangle<T>) -> PolygonType
+fn create_from_triangle_type<T>(triangle: &geo_types::Triangle<T>) -> PolygonType<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + Serialize,
 {
     create_polygon_type(&triangle.to_polygon())
 }
 
-fn create_from_rect_type<T>(rect: &geo_types::Rect<T>) -> PolygonType
+fn create_from_rect_type<T>(rect: &geo_types::Rect<T>) -> PolygonType<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + Serialize,
 {
     create_polygon_type(&rect.to_polygon())
 }
 
 fn create_multi_line_string_type<T>(
     multi_line_string: &geo_types::MultiLineString<T>,
-) -> Vec<LineStringType>
+) -> Vec<LineStringType<T>>
 where
-    T: CoordFloat,
+    T: CoordFloat + Serialize,
 {
     multi_line_string
         .0
@@ -236,9 +237,9 @@ where
         .collect()
 }
 
-fn create_polygon_type<T>(polygon: &geo_types::Polygon<T>) -> PolygonType
+fn create_polygon_type<T>(polygon: &geo_types::Polygon<T>) -> PolygonType<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + Serialize,
 {
     let mut coords = vec![polygon
         .exterior()
@@ -256,9 +257,9 @@ where
     coords
 }
 
-fn create_multi_polygon_type<T>(multi_polygon: &geo_types::MultiPolygon<T>) -> Vec<PolygonType>
+fn create_multi_polygon_type<T>(multi_polygon: &geo_types::MultiPolygon<T>) -> Vec<PolygonType<T>>
 where
-    T: CoordFloat,
+    T: CoordFloat + Serialize,
 {
     multi_polygon
         .0

--- a/src/conversion/to_geo_types.rs
+++ b/src/conversion/to_geo_types.rs
@@ -9,13 +9,13 @@ use crate::{Error, Result};
 use std::convert::{TryFrom, TryInto};
 
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
-impl<T> TryFrom<&geometry::Value> for geo_types::Point<T>
+impl<T> TryFrom<&geometry::Value<T>> for geo_types::Point<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + serde::Serialize,
 {
-    type Error = Error;
+    type Error = Error<T>;
 
-    fn try_from(value: &geometry::Value) -> Result<Self> {
+    fn try_from(value: &geometry::Value<T>) -> Result<Self, T> {
         match value {
             geometry::Value::Point(point_type) => Ok(create_geo_point(point_type)),
             other => Err(mismatch_geom_err("Point", other)),
@@ -25,13 +25,13 @@ where
 try_from_owned_value!(geo_types::Point<T>);
 
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
-impl<T> TryFrom<&geometry::Value> for geo_types::MultiPoint<T>
+impl<T> TryFrom<&geometry::Value<T>> for geo_types::MultiPoint<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + serde::Serialize,
 {
-    type Error = Error;
+    type Error = Error<T>;
 
-    fn try_from(value: &geometry::Value) -> Result<Self> {
+    fn try_from(value: &geometry::Value<T>) -> Result<Self, T> {
         match value {
             geometry::Value::MultiPoint(multi_point_type) => Ok(geo_types::MultiPoint(
                 multi_point_type
@@ -46,13 +46,13 @@ where
 try_from_owned_value!(geo_types::MultiPoint<T>);
 
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
-impl<T> TryFrom<&geometry::Value> for geo_types::LineString<T>
+impl<T> TryFrom<&geometry::Value<T>> for geo_types::LineString<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + serde::Serialize,
 {
-    type Error = Error;
+    type Error = Error<T>;
 
-    fn try_from(value: &geometry::Value) -> Result<Self> {
+    fn try_from(value: &geometry::Value<T>) -> Result<Self, T> {
         match value {
             geometry::Value::LineString(multi_point_type) => {
                 Ok(create_geo_line_string(multi_point_type))
@@ -64,13 +64,13 @@ where
 try_from_owned_value!(geo_types::LineString<T>);
 
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
-impl<T> TryFrom<&geometry::Value> for geo_types::MultiLineString<T>
+impl<T> TryFrom<&geometry::Value<T>> for geo_types::MultiLineString<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + serde::Serialize,
 {
-    type Error = Error;
+    type Error = Error<T>;
 
-    fn try_from(value: &geometry::Value) -> Result<Self> {
+    fn try_from(value: &geometry::Value<T>) -> Result<Self, T> {
         match value {
             geometry::Value::MultiLineString(multi_line_string_type) => {
                 Ok(create_geo_multi_line_string(multi_line_string_type))
@@ -82,13 +82,13 @@ where
 try_from_owned_value!(geo_types::MultiLineString<T>);
 
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
-impl<T> TryFrom<&geometry::Value> for geo_types::Polygon<T>
+impl<T> TryFrom<&geometry::Value<T>> for geo_types::Polygon<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + serde::Serialize,
 {
-    type Error = Error;
+    type Error = Error<T>;
 
-    fn try_from(value: &geometry::Value) -> Result<Self> {
+    fn try_from(value: &geometry::Value<T>) -> Result<Self, T> {
         match value {
             geometry::Value::Polygon(polygon_type) => Ok(create_geo_polygon(polygon_type)),
             other => Err(mismatch_geom_err("Polygon", other)),
@@ -98,13 +98,13 @@ where
 try_from_owned_value!(geo_types::Polygon<T>);
 
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
-impl<T> TryFrom<&geometry::Value> for geo_types::MultiPolygon<T>
+impl<T> TryFrom<&geometry::Value<T>> for geo_types::MultiPolygon<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + serde::Serialize,
 {
-    type Error = Error;
+    type Error = Error<T>;
 
-    fn try_from(value: &geometry::Value) -> Result<geo_types::MultiPolygon<T>> {
+    fn try_from(value: &geometry::Value<T>) -> Result<geo_types::MultiPolygon<T>, T> {
         match value {
             geometry::Value::MultiPolygon(multi_polygon_type) => {
                 Ok(create_geo_multi_polygon(multi_polygon_type))
@@ -116,13 +116,13 @@ where
 try_from_owned_value!(geo_types::MultiPolygon<T>);
 
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
-impl<T> TryFrom<&geometry::Value> for geo_types::GeometryCollection<T>
+impl<T> TryFrom<&geometry::Value<T>> for geo_types::GeometryCollection<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + serde::Serialize,
 {
-    type Error = Error;
+    type Error = Error<T>;
 
-    fn try_from(value: &geometry::Value) -> Result<Self> {
+    fn try_from(value: &geometry::Value<T>) -> Result<Self, T> {
         match value {
             geometry::Value::GeometryCollection(geometries) => {
                 let geojson_geometries = geometries
@@ -139,13 +139,13 @@ where
 try_from_owned_value!(geo_types::GeometryCollection<T>);
 
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
-impl<T> TryFrom<&geometry::Value> for geo_types::Geometry<T>
+impl<T> TryFrom<&geometry::Value<T>> for geo_types::Geometry<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + serde::Serialize,
 {
-    type Error = Error;
+    type Error = Error<T>;
 
-    fn try_from(value: &geometry::Value) -> Result<Self> {
+    fn try_from(value: &geometry::Value<T>) -> Result<Self, T> {
         match value {
             geometry::Value::Point(ref point_type) => {
                 Ok(geo_types::Geometry::Point(create_geo_point(point_type)))
@@ -178,7 +178,7 @@ where
                         .iter()
                         .cloned()
                         .map(|geom| geom.try_into())
-                        .collect::<Result<Vec<geo_types::Geometry<T>>>>()?,
+                        .collect::<Result<Vec<geo_types::Geometry<T>>, T>>()?,
                 ));
                 Ok(gc)
             }
@@ -191,37 +191,37 @@ macro_rules! impl_try_from_geom_value {
     ($($kind:ident),*) => {
         $(
             #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
-            impl<T> TryFrom<&$crate::Geometry> for geo_types::$kind<T>
+            impl<T> TryFrom<&$crate::Geometry<T>> for geo_types::$kind<T>
             where
-                T: CoordFloat,
+                T: CoordFloat + serde::Serialize,
             {
-                type Error = Error;
+                type Error = Error<T>;
 
-                fn try_from(geometry: &crate::Geometry) -> Result<Self> {
+                fn try_from(geometry: &crate::Geometry<T>) -> Result<Self, T> {
                     Self::try_from(&geometry.value)
                 }
             }
 
             #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
-            impl<T> TryFrom<$crate::Geometry> for geo_types::$kind<T>
+            impl<T> TryFrom<$crate::Geometry<T>> for geo_types::$kind<T>
             where
-                T: CoordFloat,
+                T: CoordFloat + serde::Serialize,
             {
-                type Error = Error;
+                type Error = Error<T>;
 
-                fn try_from(geometry: crate::Geometry) -> Result<Self> {
+                fn try_from(geometry: crate::Geometry<T>) -> Result<Self, T> {
                     Self::try_from(geometry.value)
                 }
             }
 
             #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
-            impl<T> TryFrom<$crate::Feature> for geo_types::$kind<T>
+            impl<T> TryFrom<$crate::Feature<T>> for geo_types::$kind<T>
             where
-                T: CoordFloat,
+                T: CoordFloat + serde::Serialize,
             {
-                type Error = Error;
+                type Error = Error<T>;
 
-                fn try_from(val: Feature) -> Result<Self> {
+                fn try_from(val: Feature<T>) -> Result<Self, T> {
                     match val.geometry {
                         None => Err(Error::FeatureHasNoGeometry(val)),
                         Some(geom) => geom.try_into(),
@@ -244,27 +244,27 @@ impl_try_from_geom_value![
 ];
 
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
-impl<T> TryFrom<FeatureCollection> for geo_types::Geometry<T>
+impl<T> TryFrom<FeatureCollection<T>> for geo_types::Geometry<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + serde::Serialize,
 {
-    type Error = Error;
+    type Error = Error<T>;
 
-    fn try_from(val: FeatureCollection) -> Result<geo_types::Geometry<T>> {
+    fn try_from(val: FeatureCollection<T>) -> Result<geo_types::Geometry<T>, T> {
         Ok(geo_types::Geometry::GeometryCollection(quick_collection(
-            &GeoJson::FeatureCollection(val),
+            &GeoJson::<T>::FeatureCollection(val),
         )?))
     }
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "geo-types")))]
-impl<T> TryFrom<GeoJson> for geo_types::Geometry<T>
+impl<T> TryFrom<GeoJson<T>> for geo_types::Geometry<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + serde::Serialize,
 {
-    type Error = Error;
+    type Error = Error<T>;
 
-    fn try_from(val: GeoJson) -> Result<geo_types::Geometry<T>> {
+    fn try_from(val: GeoJson<T>) -> Result<geo_types::Geometry<T>, T> {
         match val {
             GeoJson::Geometry(geom) => geom.try_into(),
             GeoJson::Feature(feat) => feat.try_into(),
@@ -273,9 +273,9 @@ where
     }
 }
 
-fn create_geo_coordinate<T>(point_type: &PointType) -> geo_types::Coordinate<T>
+fn create_geo_coordinate<T>(point_type: &PointType<T>) -> geo_types::Coordinate<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + serde::Serialize,
 {
     geo_types::Coordinate {
         x: T::from(point_type[0]).unwrap(),
@@ -283,9 +283,9 @@ where
     }
 }
 
-fn create_geo_point<T>(point_type: &PointType) -> geo_types::Point<T>
+fn create_geo_point<T>(point_type: &PointType<T>) -> geo_types::Point<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + serde::Serialize,
 {
     geo_types::Point::new(
         T::from(point_type[0]).unwrap(),
@@ -293,9 +293,9 @@ where
     )
 }
 
-fn create_geo_line_string<T>(line_type: &LineStringType) -> geo_types::LineString<T>
+fn create_geo_line_string<T>(line_type: &LineStringType<T>) -> geo_types::LineString<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + serde::Serialize,
 {
     geo_types::LineString(
         line_type
@@ -306,10 +306,10 @@ where
 }
 
 fn create_geo_multi_line_string<T>(
-    multi_line_type: &[LineStringType],
+    multi_line_type: &[LineStringType<T>],
 ) -> geo_types::MultiLineString<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + serde::Serialize,
 {
     geo_types::MultiLineString(
         multi_line_type
@@ -319,9 +319,9 @@ where
     )
 }
 
-fn create_geo_polygon<T>(polygon_type: &PolygonType) -> geo_types::Polygon<T>
+fn create_geo_polygon<T>(polygon_type: &PolygonType<T>) -> geo_types::Polygon<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + serde::Serialize,
 {
     let exterior = polygon_type
         .get(0)
@@ -340,9 +340,9 @@ where
     geo_types::Polygon::new(exterior, interiors)
 }
 
-fn create_geo_multi_polygon<T>(multi_polygon_type: &[PolygonType]) -> geo_types::MultiPolygon<T>
+fn create_geo_multi_polygon<T>(multi_polygon_type: &[PolygonType<T>]) -> geo_types::MultiPolygon<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + serde::Serialize,
 {
     geo_types::MultiPolygon(
         multi_polygon_type
@@ -352,7 +352,10 @@ where
     )
 }
 
-fn mismatch_geom_err(expected_type: &'static str, found: &geometry::Value) -> Error {
+fn mismatch_geom_err<T>(expected_type: &'static str, found: &geometry::Value<T>) -> Error<T>
+where
+    T: CoordFloat + serde::Serialize,
+{
     Error::InvalidGeometryConversion {
         expected_type,
         found_type: found.type_name(),
@@ -677,7 +680,7 @@ mod tests {
     }
 
     #[test]
-    fn borrowed_value_conversions_test() -> crate::Result<()> {
+    fn borrowed_value_conversions_test() -> crate::Result<(), f64> {
         let coord1 = vec![100.0, 0.2];
         let coord2 = vec![101.0, 1.0];
         let coord3 = vec![102.0, 0.8];

--- a/src/de.rs
+++ b/src/de.rs
@@ -225,10 +225,11 @@ where
 /// assert_eq!(features[0].name, "Downtown");
 /// assert_eq!(features[0].geometry.x(), 11.1);
 /// ```
-pub fn deserialize_geometry<'de, D, G>(deserializer: D) -> std::result::Result<G, D::Error>
+pub fn deserialize_geometry<'de, D, G, T>(deserializer: D) -> std::result::Result<G, D::Error>
 where
     D: Deserializer<'de>,
-    G: TryFrom<crate::Geometry>,
+    T: geo_types::CoordFloat + serde::Serialize,
+    G: TryFrom<crate::Geometry<T>>,
     G::Error: std::fmt::Display,
 {
     let geojson_geometry = crate::Geometry::deserialize(deserializer)?;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 
 /// Errors which can occur when encoding, decoding, and converting GeoJSON
 #[derive(Error, Debug)]
-pub enum Error {
+pub enum Error<T: geo_types::CoordFloat + serde::Serialize> {
     #[error("Encountered non-array value for a 'bbox' object: `{0}`")]
     BboxExpectedArray(Value),
     #[error("Encountered non-numeric value within 'bbox' array")]
@@ -30,7 +30,7 @@ pub enum Error {
     #[error(
         "Attempted to a convert a feature without a geometry into a geo_types::Geometry: `{0}`"
     )]
-    FeatureHasNoGeometry(Feature),
+    FeatureHasNoGeometry(Feature<T>),
     #[error("Encountered an unknown 'geometry' object type: `{0}`")]
     GeometryUnknownType(String),
     #[error("Error while deserializing JSON: {0}")]
@@ -50,7 +50,7 @@ pub enum Error {
     #[error("Expected a GeoJSON property for `{0}`, but got None")]
     ExpectedProperty(String),
     #[error("Expected a floating-point value, but got None")]
-    ExpectedF64Value,
+    ExpectedFloatValue,
     #[error("Expected an Array value, but got `{0}`")]
     ExpectedArrayValue(String),
     #[error("Expected an owned Object, but got `{0}`")]
@@ -59,15 +59,21 @@ pub enum Error {
     PositionTooShort(usize),
 }
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, U = f64> = std::result::Result<T, Error<U>>;
 
-impl From<serde_json::Error> for Error {
+impl<T> From<serde_json::Error> for Error<T>
+where
+    T: geo_types::CoordFloat + serde::Serialize,
+{
     fn from(error: serde_json::Error) -> Self {
         Self::MalformedJson(error)
     }
 }
 
-impl From<std::io::Error> for Error {
+impl<T> From<std::io::Error> for Error<T>
+where
+    T: geo_types::CoordFloat+ serde::Serialize,
+{
     fn from(error: std::io::Error) -> Self {
         Self::Io(error)
     }

--- a/src/feature_collection.rs
+++ b/src/feature_collection.rs
@@ -152,10 +152,10 @@ where
     }
 }
 
-impl <T>TryFrom<JsonValue> for FeatureCollection<T>
+impl<T> TryFrom<JsonValue> for FeatureCollection<T>
 where
     T: geo_types::CoordFloat + serde::Serialize,
- {
+{
     type Error = Error<T>;
 
     fn try_from(value: JsonValue) -> Result<Self, T> {
@@ -167,10 +167,10 @@ where
     }
 }
 
-impl<T>FromStr for FeatureCollection<T>
+impl<T> FromStr for FeatureCollection<T>
 where
     T: geo_types::CoordFloat + serde::Serialize,
- {
+{
     type Err = Error<T>;
 
     fn from_str(s: &str) -> Result<Self, T> {
@@ -204,8 +204,11 @@ where
     }
 }
 
-impl<'de> Deserialize<'de> for FeatureCollection {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<FeatureCollection, D::Error>
+impl<'de, T> Deserialize<'de> for FeatureCollection<T>
+where
+    T: geo_types::CoordFloat + serde::Serialize,
+{
+    fn deserialize<D>(deserializer: D) -> std::result::Result<FeatureCollection<T>, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -224,10 +227,10 @@ impl<'de> Deserialize<'de> for FeatureCollection {
 /// Otherwise, the output will not have a bounding-box.
 ///
 /// [`collect`]: std::iter::Iterator::collect
-impl <T>FromIterator<Feature<T>> for FeatureCollection<T>
+impl<T> FromIterator<Feature<T>> for FeatureCollection<T>
 where
     T: geo_types::CoordFloat + serde::Serialize,
- {
+{
     fn from_iter<U: IntoIterator<Item = Feature<T>>>(iter: U) -> Self {
         let mut bbox = Some(vec![]);
 
@@ -342,13 +345,15 @@ mod tests {
 
     #[test]
     fn test_from_str_ok() {
-        let feature_collection = FeatureCollection::<f64>::from_str(&feature_collection_json()).unwrap();
+        let feature_collection =
+            FeatureCollection::<f64>::from_str(&feature_collection_json()).unwrap();
         assert_eq!(2, feature_collection.features.len());
     }
 
     #[test]
     fn iter_features() {
-        let feature_collection = FeatureCollection::<f64>::from_str(&feature_collection_json()).unwrap();
+        let feature_collection =
+            FeatureCollection::<f64>::from_str(&feature_collection_json()).unwrap();
 
         let mut names: Vec<String> = vec![];
         for feature in &feature_collection {

--- a/src/feature_collection.rs
+++ b/src/feature_collection.rs
@@ -34,7 +34,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// use geojson::FeatureCollection;
 /// use geojson::GeoJson;
 ///
-/// let feature_collection = FeatureCollection {
+/// let feature_collection: FeatureCollection<f64> = FeatureCollection {
 ///     bbox: None,
 ///     features: vec![],
 ///     foreign_members: None,
@@ -53,7 +53,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// ```rust
 /// use geojson::{Feature, FeatureCollection, Value};
 ///
-/// let fc: FeatureCollection = (0..10)
+/// let fc: FeatureCollection<f64> = (0..10)
 ///     .map(|idx| -> Feature {
 ///         let c = idx as f64;
 ///         Value::Point(vec![1.0 * c, 2.0 * c, 3.0 * c]).into()
@@ -62,38 +62,50 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// assert_eq!(fc.features.len(), 10);
 /// ```
 #[derive(Clone, Debug, PartialEq)]
-pub struct FeatureCollection {
+pub struct FeatureCollection<T = f64>
+where
+    T: geo_types::CoordFloat + serde::Serialize,
+{
     /// Bounding Box
     ///
     /// [GeoJSON Format Specification § 5](https://tools.ietf.org/html/rfc7946#section-5)
-    pub bbox: Option<Bbox>,
-    pub features: Vec<Feature>,
+    pub bbox: Option<Bbox<T>>,
+    pub features: Vec<Feature<T>>,
     /// Foreign Members
     ///
     /// [GeoJSON Format Specification § 6](https://tools.ietf.org/html/rfc7946#section-6)
     pub foreign_members: Option<JsonObject>,
 }
 
-impl IntoIterator for FeatureCollection {
-    type Item = Feature;
-    type IntoIter = std::vec::IntoIter<Feature>;
+impl<T> IntoIterator for FeatureCollection<T>
+where
+    T: geo_types::CoordFloat + serde::Serialize,
+{
+    type Item = Feature<T>;
+    type IntoIter = std::vec::IntoIter<Feature<T>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.features.into_iter()
     }
 }
 
-impl<'a> IntoIterator for &'a FeatureCollection {
-    type Item = &'a Feature;
-    type IntoIter = std::slice::Iter<'a, Feature>;
+impl<'a, T> IntoIterator for &'a FeatureCollection<T>
+where
+    T: geo_types::CoordFloat + serde::Serialize,
+{
+    type Item = &'a Feature<T>;
+    type IntoIter = std::slice::Iter<'a, Feature<T>>;
 
     fn into_iter(self) -> Self::IntoIter {
         IntoIterator::into_iter(&self.features)
     }
 }
 
-impl<'a> From<&'a FeatureCollection> for JsonObject {
-    fn from(fc: &'a FeatureCollection) -> JsonObject {
+impl<'a, T> From<&'a FeatureCollection<T>> for JsonObject
+where
+    T: geo_types::CoordFloat + serde::Serialize,
+{
+    fn from(fc: &'a FeatureCollection<T>) -> JsonObject {
         // The unwrap() should never panic, because FeatureCollection contains only JSON-serializable types
         match serde_json::to_value(fc).unwrap() {
             serde_json::Value::Object(obj) => obj,
@@ -106,22 +118,28 @@ impl<'a> From<&'a FeatureCollection> for JsonObject {
     }
 }
 
-impl FeatureCollection {
-    pub fn from_json_object(object: JsonObject) -> Result<Self> {
+impl<T> FeatureCollection<T>
+where
+    T: geo_types::CoordFloat + serde::Serialize,
+{
+    pub fn from_json_object(object: JsonObject) -> Result<Self, T> {
         Self::try_from(object)
     }
 
-    pub fn from_json_value(value: JsonValue) -> Result<Self> {
+    pub fn from_json_value(value: JsonValue) -> Result<Self, T> {
         Self::try_from(value)
     }
 }
 
-impl TryFrom<JsonObject> for FeatureCollection {
-    type Error = Error;
+impl<T> TryFrom<JsonObject> for FeatureCollection<T>
+where
+    T: geo_types::CoordFloat + serde::Serialize,
+{
+    type Error = Error<T>;
 
-    fn try_from(mut object: JsonObject) -> Result<Self> {
+    fn try_from(mut object: JsonObject) -> Result<Self, T> {
         match util::expect_type(&mut object)? {
-            ref type_ if type_ == "FeatureCollection" => Ok(FeatureCollection {
+            ref type_ if type_ == "FeatureCollection" => Ok(Self {
                 bbox: util::get_bbox(&mut object)?,
                 features: util::get_features(&mut object)?,
                 foreign_members: util::get_foreign_members(object)?,
@@ -134,10 +152,13 @@ impl TryFrom<JsonObject> for FeatureCollection {
     }
 }
 
-impl TryFrom<JsonValue> for FeatureCollection {
-    type Error = Error;
+impl <T>TryFrom<JsonValue> for FeatureCollection<T>
+where
+    T: geo_types::CoordFloat + serde::Serialize,
+ {
+    type Error = Error<T>;
 
-    fn try_from(value: JsonValue) -> Result<Self> {
+    fn try_from(value: JsonValue) -> Result<Self, T> {
         if let JsonValue::Object(obj) = value {
             Self::try_from(obj)
         } else {
@@ -146,15 +167,21 @@ impl TryFrom<JsonValue> for FeatureCollection {
     }
 }
 
-impl FromStr for FeatureCollection {
-    type Err = Error;
+impl<T>FromStr for FeatureCollection<T>
+where
+    T: geo_types::CoordFloat + serde::Serialize,
+ {
+    type Err = Error<T>;
 
-    fn from_str(s: &str) -> Result<Self> {
+    fn from_str(s: &str) -> Result<Self, T> {
         Self::try_from(crate::GeoJson::from_str(s)?)
     }
 }
 
-impl Serialize for FeatureCollection {
+impl<T> Serialize for FeatureCollection<T>
+where
+    T: geo_types::CoordFloat + serde::Serialize,
+{
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -197,8 +224,11 @@ impl<'de> Deserialize<'de> for FeatureCollection {
 /// Otherwise, the output will not have a bounding-box.
 ///
 /// [`collect`]: std::iter::Iterator::collect
-impl FromIterator<Feature> for FeatureCollection {
-    fn from_iter<T: IntoIterator<Item = Feature>>(iter: T) -> Self {
+impl <T>FromIterator<Feature<T>> for FeatureCollection<T>
+where
+    T: geo_types::CoordFloat + serde::Serialize,
+ {
+    fn from_iter<U: IntoIterator<Item = Feature<T>>>(iter: U) -> Self {
         let mut bbox = Some(vec![]);
 
         let features = iter
@@ -248,7 +278,7 @@ impl FromIterator<Feature> for FeatureCollection {
                 };
             })
             .collect();
-        FeatureCollection {
+        Self {
             bbox,
             features,
             foreign_members: None,
@@ -312,13 +342,13 @@ mod tests {
 
     #[test]
     fn test_from_str_ok() {
-        let feature_collection = FeatureCollection::from_str(&feature_collection_json()).unwrap();
+        let feature_collection = FeatureCollection::<f64>::from_str(&feature_collection_json()).unwrap();
         assert_eq!(2, feature_collection.features.len());
     }
 
     #[test]
     fn iter_features() {
-        let feature_collection = FeatureCollection::from_str(&feature_collection_json()).unwrap();
+        let feature_collection = FeatureCollection::<f64>::from_str(&feature_collection_json()).unwrap();
 
         let mut names: Vec<String> = vec![];
         for feature in &feature_collection {
@@ -342,7 +372,7 @@ mod tests {
         })
         .to_string();
 
-        let actual_failure = FeatureCollection::from_str(&geometry_json).unwrap_err();
+        let actual_failure = FeatureCollection::<f64>::from_str(&geometry_json).unwrap_err();
         match actual_failure {
             Error::ExpectedType { actual, expected } => {
                 assert_eq!(actual, "Geometry");

--- a/src/feature_writer.rs
+++ b/src/feature_writer.rs
@@ -1,5 +1,5 @@
 use crate::ser::to_feature_writer;
-use crate::{Error, Feature, JsonObject, JsonValue, Result};
+use crate::{Error, Feature, Result};
 
 use serde::Serialize;
 use std::io::Write;
@@ -36,7 +36,10 @@ impl<W: Write> FeatureWriter<W> {
 
     /// Write a [`crate::Feature`] struct to the output stream. If you'd like to
     /// serialize your own custom structs, see [`FeatureWriter::serialize`] instead.
-    pub fn write_feature(&mut self, feature: &Feature) -> Result<()> {
+    pub fn write_feature<T>(&mut self, feature: &Feature<T>) -> Result<(), T>
+    where
+        T: geo_types::CoordFloat + serde::Serialize,
+    {
         match self.state {
             State::Finished => {
                 return Err(Error::InvalidWriterState(
@@ -247,15 +250,24 @@ impl<W: Write> FeatureWriter<W> {
         Ok(self.writer.flush()?)
     }
 
-    fn write_prefix(&mut self) -> Result<()> {
+    fn write_prefix<T>(&mut self) -> Result<(), T>
+    where
+        T: geo_types::CoordFloat + serde::Serialize,
+    {
         self.write_str(r#"{ "type": "FeatureCollection", "features": ["#)
     }
 
-    fn write_suffix(&mut self) -> Result<()> {
+    fn write_suffix<T>(&mut self) -> Result<(), T>
+    where
+        T: geo_types::CoordFloat + serde::Serialize,
+    {
         self.write_str("]}")
     }
 
-    fn write_str(&mut self, text: &str) -> Result<()> {
+    fn write_str<T>(&mut self, text: &str) -> Result<(), T>
+    where
+        T: geo_types::CoordFloat + serde::Serialize,
+    {
         self.writer.write_all(text.as_bytes())?;
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -419,16 +419,16 @@
 /// Bounding Boxes
 ///
 /// [GeoJSON Format Specification § 5](https://tools.ietf.org/html/rfc7946#section-5)
-pub type Bbox = Vec<f64>;
+pub type Bbox<T = f64> = Vec<T>;
 
 /// Positions
 ///
 /// [GeoJSON Format Specification § 3.1.1](https://tools.ietf.org/html/rfc7946#section-3.1.1)
-pub type Position = Vec<f64>;
+pub type Position<T = f64> = Vec<T>;
 
-pub type PointType = Position;
-pub type LineStringType = Vec<Position>;
-pub type PolygonType = Vec<Vec<Position>>;
+pub type PointType<T = f64> = Position<T>;
+pub type LineStringType<T = f64> = Vec<Position<T>>;
+pub type PolygonType<T = f64> = Vec<Vec<Position<T>>>;
 
 mod util;
 
@@ -473,15 +473,18 @@ pub use conversion::quick_collection;
 ///
 /// [GeoJSON Format Specification § 3.2](https://tools.ietf.org/html/rfc7946#section-3.2)
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct Feature {
+pub struct Feature<T = f64>
+where
+    T: geo_types::CoordFloat + serde::Serialize,
+{
     /// Bounding Box
     ///
     /// [GeoJSON Format Specification § 5](https://tools.ietf.org/html/rfc7946#section-5)
-    pub bbox: Option<Bbox>,
+    pub bbox: Option<Bbox<T>>,
     /// Geometry
     ///
     /// [GeoJSON Format Specification § 3.2](https://tools.ietf.org/html/rfc7946#section-3.2)
-    pub geometry: Option<Geometry>,
+    pub geometry: Option<Geometry<T>>,
     /// Identifier
     ///
     /// [GeoJSON Format Specification § 3.2](https://tools.ietf.org/html/rfc7946#section-3.2)

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -206,10 +206,11 @@ where
 ///
 /// Serialization can fail if `T`'s implementation of `Serialize` decides to
 /// fail, or if `T` contains a map with non-string keys.
-pub fn to_feature_collection_writer<W, T>(writer: W, features: &[T]) -> Result<()>
+pub fn to_feature_collection_writer<W, T, U >(writer: W, features: &[T]) -> Result<(), U>
 where
     W: io::Write,
     T: Serialize,
+    U: geo_types::CoordFloat + Serialize,
 {
     use serde::ser::SerializeMap;
 
@@ -253,10 +254,11 @@ where
 ///
 /// assert!(geojson_string.contains(r#""geometry":{"coordinates":[11.1,22.2],"type":"Point"}"#));
 /// ```
-pub fn serialize_geometry<IG, S>(geometry: IG, ser: S) -> std::result::Result<S::Ok, S::Error>
+pub fn serialize_geometry<IG, S, T>(geometry: IG, ser: S) -> std::result::Result<S::Ok, S::Error>
 where
-    IG: std::convert::TryInto<crate::Geometry>,
-    S: serde::Serializer,
+    T: geo_types::CoordFloat + Serialize,
+    IG: std::convert::TryInto<crate::Geometry<T>>,
+    S: Serializer,
 {
     geometry
         .try_into()
@@ -280,7 +282,7 @@ where
     }
 }
 
-impl<'a, T> serde::Serialize for Features<'a, T>
+impl<'a, T> Serialize for Features<'a, T>
 where
     T: Serialize,
 {


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Following up from my post almost a year ago in #59 , I finally got around to finishing this up!

This adds support for the generic `CoordFloat` trait to all structs provided by this crate. I've tested this locally in my OSS project and the only inconsistency I noticed was serializing with the `json!` macro from `serde_json` always resulted in `f64` precision, but I wasn't sure if that is something that can be corrected in this crate. When returning the data and letting Actix serialize it with something like `HttpResponse::Ok().json(feature)`, it respected the intended precision.

Notes for the maintainers to review:
- I'm still pretty new when it comes to Rust so there may be a lot of things that could be simplified, particularly when it comes to the Error/Result generics that were added in to account for the one error that involves generic precision. 
- Going off of the generic args I had to add to some of the tests/examples, I think I may still need to add some more `f64` defaults to make this a non-breaking change.
- I noticed a mix of how traits are added to generics, both using the `:` and `where` syntax, I tried to follow the code style as it was presented but let me know if anything should be adjusted.