### PR TITLE
use thiserror 2.0.6

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Upgrade from thiserror v1 to v2
 * Add support of serializing optional `geo-types` with `serialize_optional_geometry`.
 * Add support of deserializing optional `geo-types` with `deserialize_optional_geometry`.
 * Add support for foreign members to `FeatureWriter`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ default = ["geo-types"]
 serde = { version="~1.0", features = ["derive"] }
 serde_json = "~1.0"
 geo-types = { version = "0.7.13", features = ["serde"], optional = true }
-thiserror = "1.0.20"
+thiserror = "2.0.6"
 log = "0.4.17"
 
 [dev-dependencies]
 num-traits = "0.2"
-criterion = "0.4.0"
+criterion = "0.5.1"
 
 [[bench]]
 name = "parse"


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

