### PR TITLE
Quickly convert your custom struct to/from a single Feature

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Add `to_feature` to convert a single S: Serialize to a Feature
+* Add `from_feature` to convert a single Feature to a D: Deserialize
 * Upgrade from thiserror v1 to v2
 * Add support of serializing optional `geo-types` with `serialize_optional_geometry`.
 * Add support of deserializing optional `geo-types` with `deserialize_optional_geometry`.


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

analogous to serde_json::{[to_value](https://docs.rs/serde_json/latest/serde_json/fn.to_value.html),[from_value](https://docs.rs/serde_json/latest/serde_json/fn.from_value.html)}

We have a slew of methods for dealing with entire feature collections, but not for dealing with individual features.

Like those other "bring your own struct" methods, your custom struct must have a `geometry` field. All other fields will be mapped to feature.properties.