### PR TITLE
Custom structs support `id` field

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## Unreleased
+
+* Potentially breaking: De/Serializing your custom structs with serde now maps your struct's `id` field to `Feature.id`, rather than to `Feature.properties.id`.
+
 ## 0.24.2 - 2025-02-24
 
 * Add `to_feature` to convert a single S: Serialize to a Feature


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

FIXES #255 

Note this would be a breaking change for anyone relying on the previous behavior which serialized "id" to/from the geojson `properties.id`. We just had a breaking release (last week!), so I might want to just sit on this for a little while before publishing it.
