### PR TITLE
re-export serde error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## UNRELEASED
+
+* re-export `serde_json::Error` as `MalformedGeoJsonError`
+  * <https://github.com/georust/geojson/pull/276>
+
 ## v1.0.0 - 2025-03-16
 
 * BREAKING: `Position` is now a struct, rather than a type alias for `Vec`.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,6 @@
 //! Module for all GeoJSON-related errors
-use crate::Feature;
 use crate::geometry::deserialize::GeometryType;
+use crate::{Feature, MalformedGeoJsonError};
 use thiserror::Error;
 
 /// Errors which can occur when encoding, decoding, and converting GeoJSON
@@ -31,7 +31,7 @@ pub enum Error {
     #[error("Encountered GeometryCollection with no `geometries` key")]
     GeometryCollectionWithoutGeometriesKey,
     #[error("Error while deserializing GeoJSON: {0}")]
-    MalformedGeoJson(serde_json::Error),
+    MalformedGeoJson(MalformedGeoJsonError),
     #[error("Expected GeoJSON type `{expected}`, found `{actual}`")]
     ExpectedType { expected: String, actual: String },
     #[error("A position must contain two or more elements, but got `{0}`")]
@@ -40,8 +40,8 @@ pub enum Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-impl From<serde_json::Error> for Error {
-    fn from(error: serde_json::Error) -> Self {
+impl From<MalformedGeoJsonError> for Error {
+    fn from(error: MalformedGeoJsonError) -> Self {
         Self::MalformedGeoJson(error)
     }
 }

--- a/src/geojson.rs
+++ b/src/geojson.rs
@@ -255,7 +255,10 @@ impl fmt::Display for FeatureCollection {
 mod deserialize {
     use crate::geometry::deserialize::{Coordinates, GeometryType, RawGeometry};
     use crate::util::normalize_foreign_members;
-    use crate::{Bbox, Error, Feature, FeatureCollection, GeoJson, Geometry, JsonObject, feature};
+    use crate::{
+        Bbox, Error, Feature, FeatureCollection, GeoJson, Geometry, JsonObject,
+        MalformedGeoJsonError, feature,
+    };
     use serde::Deserialize;
     use std::convert::TryFrom;
 
@@ -327,7 +330,7 @@ mod deserialize {
                 GeoJsonType::FeatureCollection => {
                     let features = raw.features.ok_or_else(|| {
                         use serde::de::Error as _;
-                        Error::MalformedGeoJson(serde_json::Error::missing_field("features"))
+                        Error::MalformedGeoJson(MalformedGeoJsonError::missing_field("features"))
                     })?;
                     Ok(GeoJson::FeatureCollection(FeatureCollection {
                         bbox: raw.bbox,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -453,3 +453,4 @@ pub use conversion::quick_collection;
 
 pub type JsonValue = serde_json::Value;
 pub type JsonObject = serde_json::Map<String, JsonValue>;
+pub type MalformedGeoJsonError = serde_json::Error;


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---


Fixes https://github.com/georust/geojson/issues/240

We are already re-exporting some serde objects, so this doesn't create a new semver contract that wasn't already there.

And this way downstream users can interact with the error type without having to explicitly install serde_json.

