### PR TITLE
add semver checks to CI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,0 @@
-- [ ] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
-- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
----
-

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,10 +42,19 @@ jobs:
         run: cargo fmt --check
       - name: Lint using Clippy
         run: cargo clippy --tests
+  semver_checks:
+    name: Semver checks
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
   all_checks_complete:
     needs:
       - build_and_test
       - check
+      - semver_checks
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [n/a] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

I've been personally hit by a few problems which were the result of other dependencies not following semver:
- cargo error'ing because it can't unify versions
- compiler failures due to breaking changes in minor/patch releases

It's worth saying that having semver checks in *our* libraries won't fix issues with our dependencies avoiding semver, but I figure it's worthwhile implementing ourselves.

For one, it's good to be able to point to a working example of what people can do to improve their situation. As I haven't used these tools historically, this is a learning exercise for me.

Secondly, semver lawyering is complicated and requires a lot of vigalence. If I haven't already run afoul of it, it's probably only a matter of time before I do.

I tend to be a CI minimalist, so this is a bit of an experiment.

The way it will work, is the next time someone opens a PR with breaking changes, they'll be required to bump the version appropriately within their PR before CI will pass. This is different from my historic approach of leaving any "BREAKING" notes along with the CHANGELOG entry, and consulting those notes at release time to determine how to bump the version.

## Caveats

1. It seems like there are some cases that aren't caught by semver-checks[^1], like changing the return type of an existing method. I haven't looked into why this failure happens. The tool doesn't have to be perfect. We should still review changes with semver breakage in mind, and be ready to manually bump the version when we notice a breaking change.

2. I'm curious how nicely this will work within a workspace like https://github.com/georust/geo/blob/main/Cargo.toml, which patches local dependencies, e.g. so that the local `geo` build uses the local `geo-types` crate, not the published one. I think it'd be fine? In any case, we don't have to adopt this everywhere all at once.

3. From what I can tell, semver-checks doesn't fail for additive/patch changes, only breaking changes. At publication time, if no "breaking" bump has already occurred, the publisher might need to make a "minor" or "patch" version bump commit before publishing will succeed. As such, it will be important to continue to document "Added" (minor bump) changes in the CHANGELOG.

[^1]: I did some testing here: https://github.com/michaelkirk/semver_checks_demo/pull/1.  In particular, see the "change type" commits which should have failed the semver check.